### PR TITLE
Индикаторы новых заказов и подсветка QUEUED в админке; поток отзывов клиента (оценка/комментарий), отображение рейтинга у админа; бэкенд-эндпоинт и DTO для отзывов; унификация UI модалок 

### DIFF
--- a/Front/nginx.conf
+++ b/Front/nginx.conf
@@ -204,8 +204,8 @@ server {
 
     proxy_buffering    off;
     proxy_cache        off;
-    proxy_read_timeout 75s;
-    proxy_send_timeout 75s;
+    proxy_read_timeout 130s;
+    proxy_send_timeout 130s;
 
     add_header Cache-Control "no-store, no-cache, must-revalidate" always;
     add_header Pragma        "no-cache"                             always;
@@ -225,8 +225,8 @@ server {
 
     proxy_buffering    off;
     proxy_cache        off;
-    proxy_read_timeout 75s;
-    proxy_send_timeout 75s;
+    proxy_read_timeout 130s;
+    proxy_send_timeout 130s;
 
     add_header Cache-Control "no-store, no-cache, must-revalidate" always;
     add_header Pragma        "no-cache"                             always;

--- a/Front/src/components/AppHeader.vue
+++ b/Front/src/components/AppHeader.vue
@@ -39,7 +39,10 @@
             Корзина ({{ cartStore.items.length }})
           </button>
           <router-link v-if="isAdminOrOwner" to="/admin/archive">Корзина (архив)</router-link>
-          <router-link v-if="isAdminOrOwner" to="/admin">Админ</router-link>
+          <span v-if="isAdminOrOwner" class="nav-link-wrap">
+            <router-link to="/admin">Админ</router-link>
+            <span v-if="nStore.hasQueued" class="nav-dot" title="Новый заказ"></span>
+          </span>
         </template>
         <template v-else>
           <button @click="openLogin" class="nav-link btn-primary">Войти</button>
@@ -58,6 +61,7 @@
                height="28" width="28"/>
           <img v-else :src="userIcon" alt="user" class="user-chip__img user-chip__img--placeholder" height="28"
                width="28"/>
+          <span v-if="nStore.hasAnyUnread" :title="`Есть непрочитанные сообщения`" class="unread-dot"></span>
         </button>
         <transition name="fade-scale">
           <div v-if="chipHover" class="user-menu" @mouseenter="chipHover = true" @mouseleave="chipHover = false">
@@ -90,6 +94,7 @@
 import {computed, onBeforeUnmount, onMounted, ref, watch} from 'vue';
 import {useRoute, useRouter} from 'vue-router';
 import {useAuthStore} from '../store/auth';
+import {useNotificationsStore} from '../store/notifications';
 import {useCartStore} from '../store/cart';
 import {getBrandHint} from '../utils/brandHint';
 
@@ -106,6 +111,7 @@ const props = defineProps({
 const emit = defineEmits(['open-login-modal', 'open-register-modal', 'open-mini-cart']);
 const route = useRoute();
 const authStore = useAuthStore();
+const nStore = useNotificationsStore();
 const cartStore = useCartStore();
 const router = useRouter();
 const qrInlineRef = ref(qrInline);
@@ -283,6 +289,69 @@ watch(showQr, (open) => {
   outline: none;
   border-radius: 4px;
   color: #fff !important;
+}
+
+/* Avatar chip and tiny unread dot */
+.user-chip-wrap {
+  position: relative;
+}
+
+.user-chip {
+  position: relative;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 36px;
+  height: 36px;
+  border-radius: 50%;
+  border: 1px solid rgba(255, 255, 255, 0.15);
+  background: rgba(255, 255, 255, 0.06);
+  padding: 0;
+  cursor: pointer;
+}
+
+.user-chip__img {
+  width: 28px;
+  height: 28px;
+  border-radius: 50%;
+  object-fit: cover;
+  display: block;
+}
+
+.user-chip__img--placeholder {
+  background: #2f3640;
+}
+
+.unread-dot {
+  position: absolute;
+  bottom: 2px;
+  left: 2px;
+  width: 8px;
+  height: 8px;
+  border-radius: 999px;
+  background: #e53935;
+  box-shadow: 0 0 0 2px rgba(36, 36, 36, 0.9);
+}
+
+.nav-link-wrap {
+  position: relative;
+  display: inline-block;
+  margin-left: 8px;
+}
+
+.nav-link-wrap > a {
+  padding-right: 14px;
+}
+
+.nav-dot {
+  position: absolute;
+  top: -4px;
+  right: -8px;
+  width: 10px;
+  height: 10px;
+  border-radius: 999px;
+  background: #e53935;
+  box-shadow: 0 0 0 2px rgba(36, 36, 36, 0.9);
 }
 
 </style>

--- a/Front/src/components/ReviewModal.vue
+++ b/Front/src/components/ReviewModal.vue
@@ -1,0 +1,169 @@
+<template>
+  <div class="modal" @click.self="emit('close')">
+    <div class="modal__dialog">
+      <div class="modal__header">
+        <h3>Оцените заказ #{{ order?.id }}</h3>
+        <button class="btn" @click="emit('close')">×</button>
+      </div>
+      <div class="modal__body">
+        <div class="rating">
+          <button
+              v-for="n in 5"
+              :key="n"
+              :class="{ active: rating >= n }"
+              aria-label="Выставить оценку"
+              class="star"
+              type="button"
+              @click="rating = n"
+          >★
+          </button>
+        </div>
+        <div v-if="rating>0" class="improve">
+          <label v-if="rating<5" class="label">Что нам улучшить, чтобы вы поставили 5 звёзд?</label>
+          <label v-else class="label">Ваш комментарий (необязательно)</label>
+          <textarea v-model="comment" class="input" placeholder="Напишите отзыв (по желанию)" rows="4"></textarea>
+          <div v-if="rating===5" class="thanks" style="margin-top:6px;">Спасибо за высокую оценку!</div>
+        </div>
+      </div>
+      <div v-if="!alreadyReviewed" class="modal__footer">
+        <button :disabled="!rating || saving" class="btn" @click="submit">Отправить</button>
+      </div>
+      <div v-else class="modal__footer">
+        <div class="muted" style="width:100%">Отзыв уже отправлен. Изменение не требуется.</div>
+      </div>
+    </div>
+  </div>
+</template>
+
+<script setup>
+import {computed, onMounted, ref} from 'vue';
+import orderClientService from '@/services/orderClientService';
+
+const props = defineProps({
+  order: {type: Object, required: true},
+});
+const emit = defineEmits(['close', 'submitted']);
+
+const rating = ref(0);
+const comment = ref('');
+const saving = ref(false);
+
+const alreadyReviewed = computed(() => {
+  try {
+    const rated = Number.isFinite(Number(props.order?.rating)) && Number(props.order?.rating) > 0;
+    const local = localStorage.getItem('reviewed_' + props.order?.id) === '1';
+    return rated || local;
+  } catch (_) {
+    return Number(props.order?.rating) > 0;
+  }
+});
+
+onMounted(() => {
+  // Если отзыв уже существует, заполним форму значениями
+  try {
+    const r = Number(props.order?.rating ?? 0);
+    if (Number.isFinite(r) && r > 0) rating.value = r;
+    if (props.order?.reviewComment) comment.value = String(props.order.reviewComment);
+  } catch (_) {
+  }
+});
+
+async function submit() {
+  if (!rating.value) return;
+  saving.value = true;
+  try {
+    await orderClientService.submitReview(props.order.id, rating.value, comment.value || null);
+    emit('submitted', props.order.id);
+  } catch (e) {
+    // показать ошибку/тост, если нужно
+  } finally {
+    saving.value = false;
+  }
+}
+</script>
+
+<style scoped>
+.modal {
+  position: fixed;
+  inset: 0;
+  background: rgba(0, 0, 0, .45);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  z-index: 1000;
+}
+
+.modal__dialog {
+  background: var(--bg);
+  border: 1px solid var(--border);
+  border-radius: 10px;
+  width: min(520px, 96vw);
+}
+
+.modal__header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 12px;
+  border-bottom: 1px solid var(--border);
+}
+
+.modal__body {
+  padding: 12px;
+}
+
+.modal__footer {
+  padding: 12px;
+  display: flex;
+  justify-content: flex-end;
+}
+
+.btn {
+  border: 1px solid var(--border);
+  background: var(--input-bg);
+  color: var(--text);
+  border-radius: 8px;
+  padding: 6px 10px;
+  cursor: pointer;
+}
+
+.input {
+  width: 100%;
+  border: 1px solid var(--border);
+  background: var(--input-bg);
+  color: var(--text);
+  border-radius: 8px;
+  padding: 6px 10px;
+}
+
+.rating {
+  display: flex;
+  gap: 6px;
+  font-size: 28px;
+  margin-bottom: 8px;
+}
+
+.star {
+  background: transparent;
+  border: none;
+  color: #888;
+  cursor: pointer;
+  padding: 4px;
+}
+
+.star.active {
+  color: #ffd54f;
+  text-shadow: 0 0 6px rgba(255, 213, 79, .55);
+}
+
+.label {
+  display: block;
+  margin-bottom: 6px;
+  color: #bbb;
+}
+
+.thanks {
+  color: #9ccc65;
+  font-size: .95rem;
+}
+</style>

--- a/Front/src/components/ReviewTextModal.vue
+++ b/Front/src/components/ReviewTextModal.vue
@@ -1,0 +1,102 @@
+<template>
+  <div class="modal" @click.self="emit('close')">
+    <div class="modal__dialog">
+      <div class="modal__header">
+        <h3>Отзыв по заказу #{{ order?.id }}</h3>
+        <button class="btn" @click="emit('close')">×</button>
+      </div>
+      <div class="modal__body">
+        <div v-if="order?.rating" class="rating-wrap">
+          <span aria-hidden="true" class="stars">
+            <span v-for="n in 5" :key="n" :class="{ active: n <= Number(order.rating) }" class="star">★</span>
+          </span>
+          <span class="rating-text">{{ Number(order.rating).toFixed(1) }}/5</span>
+        </div>
+        <div v-else class="muted">Оценка отсутствует</div>
+        <div v-if="order?.reviewComment" class="review-text" style="margin-top:8px; white-space: pre-wrap;">
+          {{ order.reviewComment }}
+        </div>
+        <div v-else class="muted" style="margin-top:8px;">Комментарий не оставлен</div>
+      </div>
+      <div class="modal__footer">
+        <button class="btn" @click="emit('close')">Закрыть</button>
+      </div>
+    </div>
+  </div>
+</template>
+
+<script setup>
+const props = defineProps({order: {type: Object, required: true}});
+const emit = defineEmits(['close']);
+</script>
+
+<style scoped>
+.modal {
+  position: fixed;
+  inset: 0;
+  background: rgba(0, 0, 0, .45);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  z-index: 1000;
+}
+
+.modal__dialog {
+  background: var(--bg);
+  border: 1px solid var(--border);
+  border-radius: 10px;
+  width: min(520px, 96vw);
+}
+
+.modal__header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 12px;
+  border-bottom: 1px solid var(--border);
+}
+
+.modal__body {
+  padding: 12px;
+}
+
+.modal__footer {
+  padding: 12px;
+  display: flex;
+  justify-content: flex-end;
+}
+
+.btn {
+  border: 1px solid var(--border);
+  background: var(--input-bg);
+  color: var(--text);
+  border-radius: 8px;
+  padding: 6px 10px;
+  cursor: pointer;
+}
+
+.rating-wrap {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+}
+
+.stars .star {
+  color: #888;
+  font-size: 20px;
+}
+
+.stars .star.active {
+  color: #ffd54f;
+  text-shadow: 0 0 4px rgba(255, 213, 79, .5);
+}
+
+.rating-text {
+  color: #bbb;
+  font-size: .95rem;
+}
+
+.muted {
+  color: #999;
+}
+</style>

--- a/Front/src/services/notifications.js
+++ b/Front/src/services/notifications.js
@@ -1,5 +1,7 @@
 import apiClient from './api';
 import {useToast} from 'vue-toastification';
+import {useAuthStore} from '../store/auth';
+import {useNotificationsStore} from '../store/notifications';
 
 // Simple long-poll notifications client with ACK and subscription API
 class NotificationsClient {
@@ -40,10 +42,18 @@ class NotificationsClient {
         // Сервер по умолчанию ждёт до 60 секунд, можно не передавать timeoutMs
         while (this.running) {
             try {
+                // Сервер сам управляет таймаутом/пакетированием. Клиент передаёт только 'since'.
                 const resp = await apiClient.get('/notifications/longpoll', {
-                    params: {since: this.since, maxBatch: 50, timeoutMs: 25000},
-                    validateStatus: (s) => (s >= 200 && s < 300) || s === 204 || s === 201,
+                    params: {since: this.since},
                 });
+                // Обновляем индикатор непрочитанных, если сервер прислал значение
+                try {
+                    const authStore = useAuthStore();
+                    const uc = Number(resp?.data?.unreadCount);
+                    if (!Number.isNaN(uc) && uc >= 0) authStore.unreadCount = uc;
+                } catch (_) {
+                }
+
                 if (resp.status === 204 || resp.status === 201) {
                     // Нет событий — корректный idle-ответ, просто продолжаем
                     await new Promise(r => setTimeout(r, 150));
@@ -53,8 +63,41 @@ class NotificationsClient {
                 const events = Array.isArray(data?.events) ? data.events : [];
                 const nextSince = Number(data?.nextSince ?? this.since) || this.since;
                 const hasMore = !!data?.hasMore;
+                // Ещё раз обновим непрочитанные из полезной нагрузки, если есть
+                try {
+                    const authStore = useAuthStore();
+                    const uc2 = Number(data?.unreadCount);
+                    if (!Number.isNaN(uc2) && uc2 >= 0) authStore.unreadCount = uc2;
+                } catch (_) {
+                }
 
                 if (events.length > 0) {
+                    // Отметим по заказам непрочитанные для клиентской стороны (сообщения от админа)
+                    try {
+                        const nStore = useNotificationsStore();
+                        const authStore = useAuthStore();
+                        const roles = (authStore?.user?.roles) || [];
+                        const isStaff = roles.includes('ADMIN') || roles.includes('OWNER');
+                        for (const e of events) {
+                            if (e && e.type === 'COURIER_MESSAGE' && e.orderId) {
+                                // если чат по заказу открыт — не увеличиваем непрочитанные
+                                if (!nStore.isActive(e.orderId)) {
+                                    nStore.markUnread(e.orderId, 1);
+                                }
+                            } else if (e && e.type === 'CLIENT_MESSAGE' && e.orderId && isStaff) {
+                                if (!nStore.isActive(e.orderId)) {
+                                    nStore.markUnread(e.orderId, 1);
+                                }
+                            } else if (e && e.type === 'NEW_ORDER' && e.orderId && isStaff) {
+                                // новый заказ: пометим как QUEUED индикатор (визуально)
+                                nStore.markQueued(e.orderId);
+                            } else if (e && e.type === 'ORDER_STATUS_CHANGED' && e.orderId && isStaff) {
+                                const ns = String(e.newStatus || '').toUpperCase();
+                                if (ns === 'QUEUED') nStore.markQueued(e.orderId); else nStore.clearQueued(e.orderId);
+                            }
+                        }
+                    } catch (_) {
+                    }
                     // dispatch events
                     for (const e of events) {
                         this.notify(e);

--- a/Front/src/services/notificationsService.js
+++ b/Front/src/services/notificationsService.js
@@ -1,0 +1,6 @@
+import apiClient from './api';
+
+export async function getUnreadCount() {
+    const resp = await apiClient.get('/notifications/longpoll/unreadCount');
+    return typeof resp?.data === 'number' ? resp.data : 0;
+}

--- a/Front/src/services/orderClientService.js
+++ b/Front/src/services/orderClientService.js
@@ -7,6 +7,9 @@ const orderClientService = {
     myOrders() {
         return apiClient.get('/order/v1/my');
     },
+    submitReview(orderId, rating, comment) {
+        return apiClient.post(`/order/v1/orders/${orderId}/review`, {rating, comment});
+    },
 };
 
 export default orderClientService;

--- a/Front/src/store/auth.js
+++ b/Front/src/store/auth.js
@@ -14,6 +14,8 @@ export const useAuthStore = defineStore('auth', {
         isRestoringSession: false,
         // Флаг, чтобы не запускать refresh во время выхода
         isLoggingOut: false,
+        // Кол-во непрочитанных (приближённо): берём с сервера при логине
+        unreadCount: 0,
     }),
 
     getters: {
@@ -25,6 +27,7 @@ export const useAuthStore = defineStore('auth', {
         setAccessToken(accessToken) {
             this.accessToken = accessToken;
         },
+
 
         setUser(userData) {
             // Если пришёл null — явная очистка пользователя
@@ -61,6 +64,7 @@ export const useAuthStore = defineStore('auth', {
 
             this.setAccessToken(accessToken);
             this.setUser(userData);
+            // unreadCount обновляется через long-poll
         },
 
         async register(credentials) {
@@ -69,6 +73,7 @@ export const useAuthStore = defineStore('auth', {
 
             this.setAccessToken(accessToken);
             this.setUser(userData);
+            // unreadCount обновляется через long-poll
         },
 
         async checkUsername(username) {
@@ -114,6 +119,7 @@ export const useAuthStore = defineStore('auth', {
 
             this.setUser(null);
             this.setAccessToken(null);
+            this.unreadCount = 0;
             try { localStorage.removeItem(USER_STORAGE_KEY); } catch(_) {}
 
             await router.push('/');
@@ -124,6 +130,7 @@ export const useAuthStore = defineStore('auth', {
         async clearSession() {
             this.setUser(null);
             this.setAccessToken(null);
+            this.unreadCount = 0;
             try { localStorage.removeItem(USER_STORAGE_KEY); } catch(_) {}
             // Те же очистки корзины при клиентском сбросе
             try {
@@ -181,6 +188,7 @@ export const useAuthStore = defineStore('auth', {
                 return false;
             } finally {
                 this.isRestoringSession = false;
+                // unreadCount обновляется через long-poll
             }
         },
 

--- a/Front/src/store/notifications.js
+++ b/Front/src/store/notifications.js
@@ -1,0 +1,85 @@
+import {defineStore} from 'pinia';
+
+export const useNotificationsStore = defineStore('notifications', {
+    state: () => ({
+        // Непрочитанные по заказам: { [orderId]: count }
+        unreadByOrder: {},
+        // Текущий открытый чат (заказ)
+        activeOrderId: null,
+        queuedCount: 0,
+        queuedByOrder: {}, // { [orderId]: true }
+    }),
+    getters: {
+        hasUnreadByOrder: (state) => (orderId) => {
+            const id = Number(orderId);
+            return id && state.unreadByOrder[id] > 0;
+        },
+        countByOrder: (state) => (orderId) => {
+            const id = Number(orderId);
+            return id ? (state.unreadByOrder[id] || 0) : 0;
+        },
+        hasAnyUnread: (state) => Object.values(state.unreadByOrder || {}).some(v => (v | 0) > 0),
+        hasQueued: (state) => (state.queuedCount | 0) > 0,
+        isQueued: (state) => (orderId) => !!state.queuedByOrder?.[Number(orderId)],
+        isActive: (state) => (orderId) => {
+            const id = Number(orderId);
+            return !!id && Number(state.activeOrderId) === id;
+        },
+    },
+    actions: {
+        markUnread(orderId, inc = 1) {
+            const id = Number(orderId);
+            if (!id) return;
+            const cur = this.unreadByOrder[id] || 0;
+            this.unreadByOrder = {...this.unreadByOrder, [id]: cur + (Number(inc) || 1)};
+        },
+        clearOrder(orderId) {
+            const id = Number(orderId);
+            if (!id) return;
+            if (!this.unreadByOrder[id]) return;
+            const copy = {...this.unreadByOrder};
+            delete copy[id];
+            this.unreadByOrder = copy;
+        },
+        clearAll() {
+            this.unreadByOrder = {};
+            this.activeOrderId = null;
+            this.queuedCount = 0;
+            this.queuedByOrder = {};
+        },
+        setActive(orderId) {
+            const id = Number(orderId);
+            this.activeOrderId = id || null;
+        },
+        clearActive() {
+            this.activeOrderId = null;
+        },
+        setQueuedCount(n) {
+            const v = Number(n);
+            this.queuedCount = Number.isFinite(v) && v >= 0 ? v : 0;
+        },
+        markQueued(orderId) {
+            const id = Number(orderId);
+            if (!id) return;
+            if (this.queuedByOrder[id]) return;
+            this.queuedByOrder = {...this.queuedByOrder, [id]: true};
+            this.queuedCount = Object.keys(this.queuedByOrder).length;
+        },
+        clearQueued(orderId) {
+            const id = Number(orderId);
+            if (!id || !this.queuedByOrder[id]) return;
+            const copy = {...this.queuedByOrder};
+            delete copy[id];
+            this.queuedByOrder = copy;
+            this.queuedCount = Object.keys(this.queuedByOrder).length;
+        },
+        resetQueuedFromList(orders) {
+            const map = {};
+            (orders || []).forEach(o => {
+                if (o && String(o.status).toUpperCase() === 'QUEUED') map[Number(o.id)] = true;
+            });
+            this.queuedByOrder = map;
+            this.queuedCount = Object.keys(map).length;
+        }
+    },
+});

--- a/Front/src/views/HomeView.vue
+++ b/Front/src/views/HomeView.vue
@@ -230,16 +230,8 @@ const loadBrands = async () => {
 const selectBrand = async (brandId) => {
   const nextId = Number(brandId);
   const currentId = selectedBrandId.value == null ? null : Number(selectedBrandId.value);
-  const roles = authStore.user?.roles || [];
-  const isAdmin = roles.includes('ADMIN') || roles.includes('ROLE_ADMIN') || roles.includes('OWNER') || roles.includes('ROLE_OWNER');
-
-  if (!isAdmin && currentId != null && currentId !== nextId) {
-    // Для неадминов открываем другой бренд в новой вкладке
-    const url = new URL(window.location.href);
-    url.searchParams.set('brand', String(nextId));
-    window.open(url.toString(), '_blank', 'noopener');
-    return;
-  }
+  // Ранее для неадминов открывали новый бренд в новой вкладке.
+  // Теперь всегда переключаем бренд in-place без открытия новой вкладки.
 
   selectedBrandId.value = nextId;
   try {

--- a/src/main/java/kirillzhdanov/identityservice/dto/order/OrderDto.java
+++ b/src/main/java/kirillzhdanov/identityservice/dto/order/OrderDto.java
@@ -27,4 +27,7 @@ public class OrderDto {
     private LocalDateTime createdAt;
     private String comment;
     private List<OrderItemDto> items;
+    // Client review summary
+    private Integer rating; // 1..5
+    private String reviewComment;
 }

--- a/src/main/java/kirillzhdanov/identityservice/model/order/OrderReview.java
+++ b/src/main/java/kirillzhdanov/identityservice/model/order/OrderReview.java
@@ -1,0 +1,37 @@
+package kirillzhdanov.identityservice.model.order;
+
+import jakarta.persistence.*;
+import kirillzhdanov.identityservice.model.User;
+import lombok.*;
+
+import java.time.LocalDateTime;
+
+@Entity
+@Table(name = "order_review")
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class OrderReview {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "order_id", nullable = false)
+    private Order order;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "client_id", nullable = false)
+    private User client;
+
+    @Column(nullable = false)
+    private Integer rating; // 1..5
+
+    @Column(length = 4000)
+    private String comment;
+
+    @Column(nullable = false)
+    private LocalDateTime createdAt;
+}

--- a/src/main/java/kirillzhdanov/identityservice/notification/longpoll/LongPollEnvelope.java
+++ b/src/main/java/kirillzhdanov/identityservice/notification/longpoll/LongPollEnvelope.java
@@ -15,4 +15,5 @@ public class LongPollEnvelope {
     private List<LongPollEvent> events;
     private long nextSince;   // client should pass this value as 'since' in the next poll
     private boolean hasMore;  // there are more events buffered server-side beyond this page
+    private int unreadCount;  // approximate unread count for badge
 }

--- a/src/main/java/kirillzhdanov/identityservice/notification/longpoll/LongPollEvent.java
+++ b/src/main/java/kirillzhdanov/identityservice/notification/longpoll/LongPollEvent.java
@@ -24,5 +24,6 @@ public class LongPollEvent {
     private String newStatus;
 
     // Courier message payload
+    private Long messageId; // id записи OrderMessage для дедупликации
     private String text;
 }

--- a/src/main/java/kirillzhdanov/identityservice/notification/longpoll/LongPollEventType.java
+++ b/src/main/java/kirillzhdanov/identityservice/notification/longpoll/LongPollEventType.java
@@ -3,5 +3,6 @@ package kirillzhdanov.identityservice.notification.longpoll;
 public enum LongPollEventType {
     ORDER_STATUS_CHANGED,
     COURIER_MESSAGE,
-    CLIENT_MESSAGE
+    CLIENT_MESSAGE,
+    NEW_ORDER
 }

--- a/src/main/java/kirillzhdanov/identityservice/notification/longpoll/LongPollService.java
+++ b/src/main/java/kirillzhdanov/identityservice/notification/longpoll/LongPollService.java
@@ -4,19 +4,8 @@ import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 
 import java.time.Instant;
-import java.util.ArrayList;
-import java.util.Collections;
-import java.util.List;
-import java.util.Map;
-import java.util.Objects;
-import java.util.concurrent.CompletableFuture;
-import java.util.concurrent.ConcurrentHashMap;
-import java.util.concurrent.CopyOnWriteArrayList;
-import java.util.concurrent.ScheduledExecutorService;
-import java.util.concurrent.Executors;
-import java.util.concurrent.ScheduledFuture;
-import java.util.concurrent.TimeUnit;
-import java.util.stream.Collectors;
+import java.util.*;
+import java.util.concurrent.*;
 
 /**
  * In-memory long-poll broker per user.
@@ -56,10 +45,11 @@ public class LongPollService {
         enqueue(userId, evt);
     }
 
-    public void publishCourierMessage(Long userId, Long orderId, String text) {
+    public void publishCourierMessage(Long userId, Long orderId, String text, Long messageId) {
         LongPollEvent evt = LongPollEvent.builder()
                 .type(LongPollEventType.COURIER_MESSAGE)
                 .orderId(orderId)
+                .messageId(messageId)
                 .text(text)
                 .at(Instant.now())
                 .build();
@@ -67,10 +57,11 @@ public class LongPollService {
         enqueue(userId, evt);
     }
 
-    public void publishClientMessage(Long userId, Long orderId, String text) {
+    public void publishClientMessage(Long userId, Long orderId, String text, Long messageId) {
         LongPollEvent evt = LongPollEvent.builder()
                 .type(LongPollEventType.CLIENT_MESSAGE)
                 .orderId(orderId)
+                .messageId(messageId)
                 .text(text)
                 .at(Instant.now())
                 .build();
@@ -78,7 +69,13 @@ public class LongPollService {
         enqueue(userId, evt);
     }
 
-    public void publish(Long userId, LongPollEvent evt) {
+    public void publishNewOrder(Long userId, Long orderId) {
+        LongPollEvent evt = LongPollEvent.builder()
+                .type(LongPollEventType.NEW_ORDER)
+                .orderId(orderId)
+                .at(Instant.now())
+                .build();
+        log.debug("[LP] publishNewOrder userId={} orderId={}", userId, orderId);
         enqueue(userId, evt);
     }
 
@@ -135,7 +132,7 @@ public class LongPollService {
                 events = new ArrayList<>(uq.buffer.subList(fromIdx, uq.buffer.size()));
             }
             if (!events.isEmpty()) {
-                long nextSince = events.get(events.size() - 1).getId();
+                long nextSince = events.getLast().getId();
                 boolean hasMore = uq.buffer.stream().anyMatch(e -> e.getId() > nextSince);
                 log.info("[LP] poll immediate userId={} since={} -> nextSince={} events={} hasMore={} bufferSize={} waiters={}",
                         userId, since, nextSince, events.size(), hasMore, uq.buffer.size(), uq.waiters.size());
@@ -143,6 +140,7 @@ public class LongPollService {
                         .events(Collections.unmodifiableList(events))
                         .nextSince(nextSince)
                         .hasMore(hasMore)
+                        .unreadCount(uq.buffer.size())
                         .build());
                 return promise;
             }
@@ -163,6 +161,7 @@ public class LongPollService {
                             .events(List.of())
                             .nextSince(since)
                             .hasMore(false)
+                            .unreadCount(uq2.buffer.size())
                             .build());
                 }
             } catch (Exception ignored) {
@@ -211,13 +210,14 @@ public class LongPollService {
         List<LongPollEvent> events = uq.buffer.stream()
                 .filter(e -> e.getId() > since)
                 .limit(maxBatch)
-                .collect(Collectors.toList());
-        long nextSince = events.isEmpty() ? since : events.get(events.size() - 1).getId();
+                .toList();
+        long nextSince = events.isEmpty() ? since : events.getLast().getId();
         boolean hasMore = !events.isEmpty() && uq.buffer.stream().anyMatch(e -> e.getId() > nextSince);
         w.complete(LongPollEnvelope.builder()
-                .events(Collections.unmodifiableList(events))
+                .events(events)
                 .nextSince(nextSince)
                 .hasMore(hasMore)
+                .unreadCount(uq.buffer.size())
                 .build());
     }
 

--- a/src/main/java/kirillzhdanov/identityservice/repository/order/OrderReviewRepository.java
+++ b/src/main/java/kirillzhdanov/identityservice/repository/order/OrderReviewRepository.java
@@ -1,0 +1,12 @@
+package kirillzhdanov.identityservice.repository.order;
+
+import kirillzhdanov.identityservice.model.order.OrderReview;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+import java.util.Optional;
+
+@Repository
+public interface OrderReviewRepository extends JpaRepository<OrderReview, Long> {
+    Optional<OrderReview> findByOrder_Id(Long orderId);
+}

--- a/src/main/java/kirillzhdanov/identityservice/security/SecurityConfig.java
+++ b/src/main/java/kirillzhdanov/identityservice/security/SecurityConfig.java
@@ -41,7 +41,10 @@ public class SecurityConfig {
         http.csrf(AbstractHttpConfigurer::disable)
                 .authorizeHttpRequests(auth -> auth
                         .requestMatchers(HttpMethod.OPTIONS, "/**").permitAll() // CORS preflight
-                        .requestMatchers("/notifications/longpoll/**").authenticated()
+                        // Long-poll: GET /notifications/longpoll доступен всем (контроллер вернёт 204 для неавторизованных)
+                        .requestMatchers(HttpMethod.GET, "/notifications/longpoll").permitAll()
+                        // ACK и unreadCount доступны только авторизованным
+                        .requestMatchers("/notifications/longpoll/ack", "/notifications/longpoll/unreadCount").authenticated()
                         .requestMatchers("/auth/v1/login")
                         .permitAll()
                         .requestMatchers("/auth/v1/register")

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -1,7 +1,7 @@
 server:
   port: ${SERVER_PORT:9900}
   tomcat:
-    connection-timeout: 70s
+    connection-timeout: 120s
   servlet:
     session:
       cookie:
@@ -18,7 +18,7 @@ spring:
     open-in-view: false
   mvc:
     async:
-      request-timeout: 65s
+      request-timeout: 120s
   show-sql: false
   properties:
     hibernate:

--- a/src/main/resources/db/changelog/2025/09/27-01-changelog.xml
+++ b/src/main/resources/db/changelog/2025/09/27-01-changelog.xml
@@ -1,0 +1,39 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<databaseChangeLog
+        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+        xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog
+                      http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-4.31.xsd"
+        objectQuotingStrategy="QUOTE_ONLY_RESERVED_WORDS">
+    <changeSet id="1759001540540-1" author="RillG">
+        <createTable tableName="order_review">
+            <column autoIncrement="true" name="id" type="BIGINT">
+                <constraints nullable="false" primaryKey="true" primaryKeyName="pk_order_review"/>
+            </column>
+            <column name="order_id" type="BIGINT">
+                <constraints nullable="false"/>
+            </column>
+            <column name="client_id" type="BIGINT">
+                <constraints nullable="false"/>
+            </column>
+            <column name="rating" type="INT">
+                <constraints nullable="false"/>
+            </column>
+            <column name="comment" type="VARCHAR(4000)"/>
+            <column name="created_at" type="DATETIME">
+                <constraints nullable="false"/>
+            </column>
+        </createTable>
+    </changeSet>
+    <changeSet id="1759001540540-2" author="RillG">
+        <addForeignKeyConstraint baseColumnNames="client_id" baseTableName="order_review"
+                                 constraintName="FK_ORDER_REVIEW_ON_CLIENT" referencedColumnNames="id"
+                                 referencedTableName="users"/>
+    </changeSet>
+    <changeSet id="1759001540540-3" author="RillG">
+        <addForeignKeyConstraint baseColumnNames="order_id" baseTableName="order_review"
+                                 constraintName="FK_ORDER_REVIEW_ON_ORDER" referencedColumnNames="id"
+                                 referencedTableName="orders"/>
+    </changeSet>
+
+</databaseChangeLog>

--- a/src/main/resources/db/changelog/db.changelog-master.xml
+++ b/src/main/resources/db/changelog/db.changelog-master.xml
@@ -9,6 +9,7 @@
     <include file="/db/changelog/2025/09/23-02-changelog.xml"/>
     <include file="/db/changelog/2025/09/23-03-changelog.xml"/>
     <include file="db/changelog/2025/09/24-01-changelog.xml"/>
+    <include file="db/changelog/2025/09/27-01-changelog.xml"/>
 
 
 </databaseChangeLog>


### PR DESCRIPTION

## Что сделано

- Backend
    - Добавлен эндпоинт клиента для отзывов: `POST /order/v1/orders/{id}/review` (только владелец заказа, только при `COMPLETED`, 1–5 звёзд, комментарий опционален, защита от повторной отправки 409).
    - Создана сущность `OrderReview` + репозиторий `OrderReviewRepository`.
    - В `OrderDto` добавлены поля `rating` и `reviewComment`. Заполнение на стороне админ-сервиса.
    - Исправлен `OrderController.getOrderMessages(...)` (права доступа + правильный вызов репозитория `findByOrder_IdOrderByIdAsc`).
    - Добавлен helper `isAuthenticated(...)`.
    - Liquibase: создан changelog для таблицы `order_review` с FK на `users` и `orders`.

    - Long-poll (сервер)
        - Исправлена логика рассылки клиентских сообщений персоналу бренда: отправитель-клиент больше не уведомляется самим событием (исключён из списка адресатов), добавлена дедупликация по `userId`.
        - В события `CLIENT_MESSAGE` добавлен `messageId` — для фронтенд‑дедупликации (чтобы не дублировать одно и то же сообщение в UI при повторной доставке).
        - Публикация событий о жизненном цикле заказа используется для визуальных индикаторов:
            - `NEW_ORDER` — для пометки новых заказов (статус `QUEUED`).
            - `ORDER_STATUS_CHANGED` — для синхронизации статусов и сброса индикаторов `QUEUED` при переводе заказа в иной статус.

- Frontend — клиент
    - Реализован модальный интерфейс отзывов `ReviewModal.vue`:
        - Выбор 1–5 звёзд, комментарий доступен для любой оценки (в т.ч. 5 звёзд).
        - Если отзыв уже существует — форма предзаполняется значениями и кнопка «Отправить» скрыта.
    - В `MyOrdersView.vue` и `ProfileView.vue`:
        - Кнопка «Оценить заказ» показывается только для завершённых заказов без отзыва.
        - Кнопка «Посмотреть отзыв» открывает редактируемую модалку, уже заполняя данными пользователя.
    - Компонент карточки `OrderListItem.vue`:
        - Звёзды вынесены в заголовок рядом с номером заказа.
        - Текст отзыва убран из карточки (просмотр — через модалку).
        - Исправлены эмиты событий (`open-review`, `open-review-text`) и обработчики.
        - Исправлена ошибка стилей (незакрытый блок CSS), из-за которой падал Vite.

- Frontend — админ
    - `AdminOrdersView.vue`:
        - Плашки и визуальные индикаторы для новых заказов:
            - Красная точка у ID и подсветка строки для статуса `QUEUED`.
            - Колонка «Новые» показывает количество непрочитанных сообщений.
        - Отображение рейтинга (звёзды + `N/5`) под кнопкой «Сообщение».
        - Кнопка «Отзыв» всегда активна (если комментария нет — модалка скажет «Комментарий не оставлен»).
        - Очистка индикатора `QUEUED` при смене статуса.
    - Хедер `AppHeader.vue`:
        - Красная точка у ссылки «Админ», если есть заказы в `QUEUED`.

- Frontend — нотификации
    - Хранилище `useNotificationsStore` расширено полями `queuedByOrder`/`queuedCount`, геттером `hasQueued` и экшенами `markQueued/clearQueued/resetQueuedFromList`.
    - Клиент long-poll (`services/notifications.js`):
        - Обработка событий `NEW_ORDER` → `markQueued` (для ролей ADMIN/OWNER).
        - `ORDER_STATUS_CHANGED` → если `QUEUED` → `markQueued`, иначе `clearQueued`.

## Как проверить

- Клиент
    - Оформить заказ → после перевода в `COMPLETED` в карточке появится «Оценить заказ».
    - Открыть модалку, проставить звёзды и комментарий, отправить → кнопка «Оценить заказ» исчезает, рядом с номером заказа появляются звёзды.
    - При повторном открытии через «Посмотреть отзыв» поля заполнены, кнопки «Отправить» нет.

- Админ
    - При новом заказе:
        - слышен звук,
        - в шапке «Админ» — красная точка,
        - в таблице заказов: строка `QUEUED` подсвечена и у ID — красная точка.
    - При смене статуса с `QUEUED` индикатор исчезает.
    - Рейтинг и «Отзыв» доступны под «Сообщение».

## Миграции

- Liquibase changelog: `src/main/resources/db/changelog/2025/09/27-01-changelog.xml` — добавляет таблицу `order_review`.

## Совместимость и риски

- API добавлен, существующие не ломаются.
- Новые поля в `OrderDto` — фронт поддержан.
- Проверить, что long-poll отправляет события `NEW_ORDER` и `ORDER_STATUS_CHANGED` с корректными полями.

## Примечания

- При необходимости можно включить режим редактирования отзыва (снять 409 на бэке). Сейчас — один отзыв на заказ.
- Стили модалок унифицированы: используются те же базовые классы, что и в `ChatModal.vue`.
