### PR TITLE
TASK-1.3: JWT-контекст и глобальная фильтрация доступа + контекстный switch endpoint и интеграционные тесты  

### DIFF
--- a/src/main/java/kirillzhdanov/identityservice/controller/ContextController.java
+++ b/src/main/java/kirillzhdanov/identityservice/controller/ContextController.java
@@ -1,0 +1,70 @@
+package kirillzhdanov.identityservice.controller;
+
+import kirillzhdanov.identityservice.dto.ContextSwitchRequest;
+import kirillzhdanov.identityservice.dto.ContextSwitchResponse;
+import kirillzhdanov.identityservice.exception.BadRequestException;
+import kirillzhdanov.identityservice.model.Token;
+import kirillzhdanov.identityservice.model.User;
+import kirillzhdanov.identityservice.model.master.UserMembership;
+import kirillzhdanov.identityservice.repository.UserRepository;
+import kirillzhdanov.identityservice.repository.master.UserMembershipRepository;
+import kirillzhdanov.identityservice.security.CustomUserDetails;
+import kirillzhdanov.identityservice.security.JwtUtils;
+import kirillzhdanov.identityservice.service.TokenService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.Objects;
+
+@RestController
+@RequestMapping("/auth/v1/context")
+@RequiredArgsConstructor
+public class ContextController {
+
+    private final UserMembershipRepository membershipRepository;
+    private final UserRepository userRepository;
+    private final JwtUtils jwtUtils;
+    private final TokenService tokenService;
+
+    @PostMapping("/switch")
+    public ResponseEntity<ContextSwitchResponse> switchContext(@RequestBody ContextSwitchRequest request) {
+        if (request.getMembershipId() == null) {
+            throw new BadRequestException("membershipId is required");
+        }
+        Authentication auth = SecurityContextHolder.getContext().getAuthentication();
+        if (auth == null || !auth.isAuthenticated()) {
+            throw new BadRequestException("Not authenticated");
+        }
+        String username = auth.getName();
+        User user = userRepository.findByUsername(username)
+                .orElseThrow(() -> new BadRequestException("User not found"));
+
+        UserMembership membership = membershipRepository.findById(request.getMembershipId())
+                .orElseThrow(() -> new BadRequestException("Membership not found"));
+        if (!Objects.equals(membership.getUser().getId(), user.getId())) {
+            throw new BadRequestException("Membership does not belong to current user");
+        }
+
+        Long masterId = membership.getMaster() != null ? membership.getMaster().getId() : null;
+        // validate overrides: if provided and mismatch - 400
+        if (request.getBrandId() != null && membership.getBrand() != null && !Objects.equals(request.getBrandId(), membership.getBrand().getId())) {
+            throw new BadRequestException("brandId override does not match membership");
+        }
+        if (request.getLocationId() != null && membership.getPickupPoint() != null && !Objects.equals(request.getLocationId(), membership.getPickupPoint().getId())) {
+            throw new BadRequestException("locationId override does not match membership");
+        }
+        Long brandId = request.getBrandId() != null ? request.getBrandId() : (membership.getBrand() != null ? membership.getBrand().getId() : null);
+        Long locationId = request.getLocationId() != null ? request.getLocationId() : (membership.getPickupPoint() != null ? membership.getPickupPoint().getId() : null);
+
+        String accessToken = jwtUtils.generateAccessToken(new CustomUserDetails(user),
+                membership.getId(), masterId, brandId, locationId);
+        tokenService.saveToken(accessToken, Token.TokenType.ACCESS, user);
+        return ResponseEntity.ok(new ContextSwitchResponse(accessToken));
+    }
+}

--- a/src/main/java/kirillzhdanov/identityservice/dto/ContextSwitchRequest.java
+++ b/src/main/java/kirillzhdanov/identityservice/dto/ContextSwitchRequest.java
@@ -1,0 +1,10 @@
+package kirillzhdanov.identityservice.dto;
+
+import lombok.Data;
+
+@Data
+public class ContextSwitchRequest {
+    private Long membershipId; // required
+    private Long brandId;      // optional override
+    private Long locationId;   // optional override
+}

--- a/src/main/java/kirillzhdanov/identityservice/dto/ContextSwitchResponse.java
+++ b/src/main/java/kirillzhdanov/identityservice/dto/ContextSwitchResponse.java
@@ -1,0 +1,10 @@
+package kirillzhdanov.identityservice.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+
+@Data
+@AllArgsConstructor
+public class ContextSwitchResponse {
+    private String accessToken;
+}

--- a/src/main/java/kirillzhdanov/identityservice/security/JwtUtils.java
+++ b/src/main/java/kirillzhdanov/identityservice/security/JwtUtils.java
@@ -104,6 +104,28 @@ public class JwtUtils {
 		return createToken(claims, userDetails.getUsername(), accessTokenExpiration);
 	}
 
+	public String generateAccessToken(UserDetails userDetails,
+									  Long membershipId,
+									  Long masterId,
+									  Long brandId,
+									  Long locationId) {
+		Map<String, Object> claims = new HashMap<>();
+		claims.put("tokenType", Token.TokenType.ACCESS.name());
+		if (userDetails instanceof CustomUserDetails(User user)) {
+			claims.put("userId", user.getId());
+			claims.put("username", user.getUsername());
+			List<Long> brandIds = user.getBrands().stream().map(Brand::getId).collect(Collectors.toList());
+			claims.put("brandIds", brandIds);
+			List<String> roles = user.getRoles().stream().map(role -> role.getName().name()).collect(Collectors.toList());
+			claims.put("roles", roles);
+		}
+		if (membershipId != null) claims.put("membershipId", membershipId);
+		if (masterId != null) claims.put("masterId", masterId);
+		if (brandId != null) claims.put("brandId", brandId);
+		if (locationId != null) claims.put("locationId", locationId);
+		return createToken(claims, userDetails.getUsername(), accessTokenExpiration);
+	}
+
 	public String generateRefreshToken(UserDetails userDetails) {
 
 		Map<String, Object> claims = new HashMap<>();
@@ -165,6 +187,34 @@ public class JwtUtils {
 		return extractClaim(token, claims -> {
 			Object roles = claims.get("roles");
 			return roles != null ? (List<String>) roles : Collections.emptyList();
+		});
+	}
+
+	public Long extractMembershipId(String token) {
+		return extractClaim(token, claims -> {
+			Object v = claims.get("membershipId");
+			return v != null ? ((Number) v).longValue() : null;
+		});
+	}
+
+	public Long extractMasterIdClaim(String token) {
+		return extractClaim(token, claims -> {
+			Object v = claims.get("masterId");
+			return v != null ? ((Number) v).longValue() : null;
+		});
+	}
+
+	public Long extractBrandIdClaim(String token) {
+		return extractClaim(token, claims -> {
+			Object v = claims.get("brandId");
+			return v != null ? ((Number) v).longValue() : null;
+		});
+	}
+
+	public Long extractLocationIdClaim(String token) {
+		return extractClaim(token, claims -> {
+			Object v = claims.get("locationId");
+			return v != null ? ((Number) v).longValue() : null;
 		});
 	}
 

--- a/src/main/java/kirillzhdanov/identityservice/tenant/ContextEnforcementFilter.java
+++ b/src/main/java/kirillzhdanov/identityservice/tenant/ContextEnforcementFilter.java
@@ -1,0 +1,77 @@
+package kirillzhdanov.identityservice.tenant;
+
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import org.springframework.http.HttpMethod;
+import org.springframework.lang.NonNull;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.web.filter.OncePerRequestFilter;
+
+import java.io.IOException;
+import java.util.Set;
+
+/**
+ * Enforces presence of tenant context for protected endpoints.
+ * Skips public endpoints and the context switch endpoint.
+ */
+public class ContextEnforcementFilter extends OncePerRequestFilter {
+
+    private static final Set<String> PUBLIC_PREFIXES = Set.of(
+            // Auth endpoints, которые не требуют tenant-контекста
+            "/auth/v1/login",
+            "/auth/v1/register",
+            "/auth/v1/refresh",
+            "/auth/v1/checkUsername",
+            "/auth/v1/context/switch",
+            "/auth/v1/revoke",
+            "/auth/v1/revoke-all",
+            "/auth/v1/logout",
+            "/auth/v1/logout/all",
+            // User-пути не завязаны на tenant-контекст
+            "/user/v1/",
+            // Публичные/документация
+            "/oauth2/authorization",
+            "/login/oauth2/code",
+            "/notifications/longpoll",
+            "/menu/",
+            "/public/",
+            "/swagger-ui",
+            "/api-docs",
+            "/v3/api-docs",
+            "/status"
+    );
+
+    private boolean isPublic(HttpServletRequest request) {
+        String uri = request.getRequestURI();
+        if (HttpMethod.OPTIONS.matches(request.getMethod())) return true;
+        for (String p : PUBLIC_PREFIXES) {
+            if (uri.startsWith(p)) return true;
+        }
+        // Allow GET menu endpoints explicitly
+        return request.getMethod().equals("GET") && (uri.startsWith("/menu/") || "/orders".equals(uri));
+    }
+
+    @Override
+    protected void doFilterInternal(@NonNull HttpServletRequest request,
+                                    @NonNull HttpServletResponse response,
+                                    @NonNull FilterChain filterChain) throws ServletException, IOException {
+        if (isPublic(request)) {
+            filterChain.doFilter(request, response);
+            return;
+        }
+        // Enforce only for authenticated requests
+        Authentication auth = SecurityContextHolder.getContext().getAuthentication();
+        boolean authenticated = auth != null && auth.isAuthenticated();
+        if (authenticated) {
+            // Require context for authenticated, protected requests; if not set -> 403
+            if (TenantContext.getMasterId() == null) {
+                response.sendError(HttpServletResponse.SC_FORBIDDEN);
+                return;
+            }
+        }
+        filterChain.doFilter(request, response);
+    }
+}

--- a/src/main/java/kirillzhdanov/identityservice/tenant/TenantContext.java
+++ b/src/main/java/kirillzhdanov/identityservice/tenant/TenantContext.java
@@ -2,6 +2,9 @@ package kirillzhdanov.identityservice.tenant;
 
 public final class TenantContext {
     private static final ThreadLocal<Long> MASTER_ID = new ThreadLocal<>();
+    private static final ThreadLocal<Long> MEMBERSHIP_ID = new ThreadLocal<>();
+    private static final ThreadLocal<Long> BRAND_ID = new ThreadLocal<>();
+    private static final ThreadLocal<Long> LOCATION_ID = new ThreadLocal<>();
 
     private TenantContext() {
     }
@@ -22,5 +25,32 @@ public final class TenantContext {
 
     public static void clear() {
         MASTER_ID.remove();
+        MEMBERSHIP_ID.remove();
+        BRAND_ID.remove();
+        LOCATION_ID.remove();
+    }
+
+    public static Long getMembershipId() {
+        return MEMBERSHIP_ID.get();
+    }
+
+    public static void setMembershipId(Long membershipId) {
+        MEMBERSHIP_ID.set(membershipId);
+    }
+
+    public static Long getBrandId() {
+        return BRAND_ID.get();
+    }
+
+    public static void setBrandId(Long brandId) {
+        BRAND_ID.set(brandId);
+    }
+
+    public static Long getLocationId() {
+        return LOCATION_ID.get();
+    }
+
+    public static void setLocationId(Long locationId) {
+        LOCATION_ID.set(locationId);
     }
 }

--- a/src/test/java/kirillzhdanov/identityservice/controller/BrandControllerJwtContextIntegrationTest.java
+++ b/src/test/java/kirillzhdanov/identityservice/controller/BrandControllerJwtContextIntegrationTest.java
@@ -4,19 +4,21 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import jakarta.servlet.http.Cookie;
 import kirillzhdanov.identityservice.config.IntegrationTestBase;
 import kirillzhdanov.identityservice.dto.BrandDto;
+import kirillzhdanov.identityservice.dto.ContextSwitchRequest;
 import kirillzhdanov.identityservice.dto.UserRegistrationRequest;
 import kirillzhdanov.identityservice.dto.UserResponse;
 import kirillzhdanov.identityservice.model.Role;
 import kirillzhdanov.identityservice.model.master.MasterAccount;
+import kirillzhdanov.identityservice.model.master.UserMembership;
+import kirillzhdanov.identityservice.repository.UserRepository;
 import kirillzhdanov.identityservice.repository.master.MasterAccountRepository;
-import org.junit.jupiter.api.BeforeEach;
+import kirillzhdanov.identityservice.repository.master.UserMembershipRepository;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
 import org.springframework.http.MediaType;
 import org.springframework.test.annotation.DirtiesContext;
-import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.MvcResult;
 
@@ -31,20 +33,19 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 @AutoConfigureMockMvc
-@ActiveProfiles("dev")
 @DirtiesContext(classMode = DirtiesContext.ClassMode.AFTER_EACH_TEST_METHOD)
-public class BrandControllerContextIntegrationTest extends IntegrationTestBase {
+public class BrandControllerJwtContextIntegrationTest extends IntegrationTestBase {
 
     @Autowired
     private MockMvc mockMvc;
-
     @Autowired
     private ObjectMapper objectMapper;
-
     @Autowired
     private MasterAccountRepository masterRepo;
-
-    private Cookie authCookie;
+    @Autowired
+    private UserRepository userRepo;
+    @Autowired
+    private UserMembershipRepository membershipRepo;
 
     private Cookie registerAndLogin(String username) throws Exception {
         UserRegistrationRequest req = new UserRegistrationRequest();
@@ -53,7 +54,6 @@ public class BrandControllerContextIntegrationTest extends IntegrationTestBase {
         Set<Role.RoleName> roles = new HashSet<>();
         roles.add(Role.RoleName.USER);
         req.setRoleNames(roles);
-
         MvcResult res = mockMvc
                 .perform(post("/auth/v1/register")
                         .contentType(MediaType.APPLICATION_JSON)
@@ -65,67 +65,62 @@ public class BrandControllerContextIntegrationTest extends IntegrationTestBase {
         return new Cookie("accessToken", created.getAccessToken());
     }
 
-    @BeforeEach
-    void setup() throws Exception {
-        authCookie = registerAndLogin("ctx-user");
+    private Cookie switchContext(Cookie authCookie, Long membershipId) throws Exception {
+        ContextSwitchRequest req = new ContextSwitchRequest();
+        req.setMembershipId(membershipId);
+        MvcResult sw = mockMvc.perform(post("/auth/v1/context/switch")
+                        .cookie(authCookie)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(req)))
+                .andExpect(status().isOk())
+                .andReturn();
+        String accessToken = objectMapper.readTree(sw.getResponse().getContentAsString()).get("accessToken").asText();
+        return new Cookie("accessToken", accessToken);
     }
 
     @Test
-    @DisplayName("Создание бренда и листинг работают в рамках X-Master-Id (контекст-лайт)")
-    void createAndListScopedByMaster() throws Exception {
-        // Arrange: два мастера
+    @DisplayName("JWT-контекст: изоляция брендов по master")
+    void brandsIsolationByMaster_WithJwtContext() throws Exception {
+        Cookie login = registerAndLogin("jwtctx-user");
+        Long userId = userRepo.findByUsername("jwtctx-user").orElseThrow().getId();
+
+        // Два мастера и членства
         MasterAccount m1 = masterRepo.save(MasterAccount.builder().name("M1").status("ACTIVE").build());
         MasterAccount m2 = masterRepo.save(MasterAccount.builder().name("M2").status("ACTIVE").build());
+        UserMembership um1 = new UserMembership();
+        um1.setUser(userRepo.findById(userId).orElseThrow());
+        um1.setMaster(m1);
+        UserMembership um2 = new UserMembership();
+        um2.setUser(userRepo.findById(userId).orElseThrow());
+        um2.setMaster(m2);
+        Long mem1 = membershipRepo.save(um1).getId();
+        Long mem2 = membershipRepo.save(um2).getId();
 
-        // Act: создаём бренд в M1
-        BrandDto dto = BrandDto.builder().name("Brand-A").organizationName("OrgA").build();
+        // Переключаемся в контекст M1
+        Cookie ctxM1 = switchContext(login, mem1);
+
+        // Создаём бренд в M1
+        BrandDto dto = BrandDto.builder().name("Brand-JWT-A").organizationName("OrgA").build();
         mockMvc.perform(post("/auth/v1/brands")
-                        .cookie(authCookie)
-                        .header("X-Master-Id", m1.getId())
+                        .cookie(ctxM1)
                         .contentType(MediaType.APPLICATION_JSON)
                         .content(objectMapper.writeValueAsString(dto)))
                 .andExpect(status().isCreated())
-                .andExpect(jsonPath("$.name").value("Brand-A"));
+                .andExpect(jsonPath("$.name").value("Brand-JWT-A"));
 
-        // Проверяем, что в M1 видим 1 бренд
-        MvcResult listM1 = mockMvc.perform(get("/auth/v1/brands")
-                        .cookie(authCookie)
-                        .header("X-Master-Id", m1.getId()))
+        // Листинг в M1 содержит бренд
+        MvcResult listM1 = mockMvc.perform(get("/auth/v1/brands").cookie(ctxM1))
                 .andExpect(status().isOk())
                 .andReturn();
         List<?> m1Brands = objectMapper.readValue(listM1.getResponse().getContentAsString(), List.class);
         assertThat(m1Brands).hasSize(1);
 
-        // А в M2 список пуст
-        MvcResult listM2 = mockMvc.perform(get("/auth/v1/brands")
-                        .cookie(authCookie)
-                        .header("X-Master-Id", m2.getId()))
+        // Переключаемся в контекст M2 и проверяем изоляцию
+        Cookie ctxM2 = switchContext(login, mem2);
+        MvcResult listM2 = mockMvc.perform(get("/auth/v1/brands").cookie(ctxM2))
                 .andExpect(status().isOk())
                 .andReturn();
         List<?> m2Brands = objectMapper.readValue(listM2.getResponse().getContentAsString(), List.class);
         assertThat(m2Brands).isEmpty();
-    }
-
-    @Test
-    @DisplayName("Доступ к бренду другого мастера недоступен (404 в текущем контексте)")
-    void getForeignMasterBrand_NotFound() throws Exception {
-        // Arrange: создаём мастера и бренд под M1
-        MasterAccount m1 = masterRepo.save(MasterAccount.builder().name("M1").status("ACTIVE").build());
-        BrandDto dto = BrandDto.builder().name("Brand-X").organizationName("OrgX").build();
-        MvcResult createdRes = mockMvc.perform(post("/auth/v1/brands")
-                        .cookie(authCookie)
-                        .header("X-Master-Id", m1.getId())
-                        .contentType(MediaType.APPLICATION_JSON)
-                        .content(objectMapper.writeValueAsString(dto)))
-                .andExpect(status().isCreated())
-                .andReturn();
-        BrandDto created = objectMapper.readValue(createdRes.getResponse().getContentAsString(), BrandDto.class);
-
-        // Act: другой мастер
-        MasterAccount m2 = masterRepo.save(MasterAccount.builder().name("M2").status("ACTIVE").build());
-        mockMvc.perform(get("/auth/v1/brands/" + created.getId())
-                        .cookie(authCookie)
-                        .header("X-Master-Id", m2.getId()))
-                .andExpect(status().is4xxClientError()); // 404 по нашей бизнес-логике
     }
 }

--- a/src/test/java/kirillzhdanov/identityservice/controller/ContextControllerIntegrationTest.java
+++ b/src/test/java/kirillzhdanov/identityservice/controller/ContextControllerIntegrationTest.java
@@ -1,0 +1,170 @@
+package kirillzhdanov.identityservice.controller;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import jakarta.servlet.http.Cookie;
+import kirillzhdanov.identityservice.config.IntegrationTestBase;
+import kirillzhdanov.identityservice.dto.ContextSwitchRequest;
+import kirillzhdanov.identityservice.dto.UserRegistrationRequest;
+import kirillzhdanov.identityservice.dto.UserResponse;
+import kirillzhdanov.identityservice.model.Brand;
+import kirillzhdanov.identityservice.model.Role;
+import kirillzhdanov.identityservice.model.master.MasterAccount;
+import kirillzhdanov.identityservice.model.master.UserMembership;
+import kirillzhdanov.identityservice.model.pickup.PickupPoint;
+import kirillzhdanov.identityservice.repository.BrandRepository;
+import kirillzhdanov.identityservice.repository.UserRepository;
+import kirillzhdanov.identityservice.repository.master.MasterAccountRepository;
+import kirillzhdanov.identityservice.repository.master.UserMembershipRepository;
+import kirillzhdanov.identityservice.repository.pickup.PickupPointRepository;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.http.MediaType;
+import org.springframework.test.annotation.DirtiesContext;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.MvcResult;
+
+import java.math.BigDecimal;
+import java.util.HashSet;
+import java.util.Set;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@AutoConfigureMockMvc
+@DirtiesContext(classMode = DirtiesContext.ClassMode.AFTER_EACH_TEST_METHOD)
+public class ContextControllerIntegrationTest extends IntegrationTestBase {
+
+    @Autowired
+    private MockMvc mockMvc;
+    @Autowired
+    private ObjectMapper objectMapper;
+
+    @Autowired
+    private MasterAccountRepository masterRepo;
+    @Autowired
+    private UserMembershipRepository membershipRepo;
+    @Autowired
+    private UserRepository userRepo;
+    @Autowired
+    private BrandRepository brandRepo;
+    @Autowired
+    private PickupPointRepository pickupRepo;
+
+    private Cookie registerAndLogin(String username) throws Exception {
+        UserRegistrationRequest req = new UserRegistrationRequest();
+        req.setUsername(username);
+        req.setPassword("Password123!");
+        Set<Role.RoleName> roles = new HashSet<>();
+        roles.add(Role.RoleName.USER);
+        req.setRoleNames(roles);
+        MvcResult res = mockMvc
+                .perform(post("/auth/v1/register")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(req)))
+                .andExpect(status().isCreated())
+                .andReturn();
+        UserResponse created = objectMapper.readValue(res.getResponse().getContentAsString(), UserResponse.class);
+        assertThat(created.getAccessToken()).isNotBlank();
+        return new Cookie("accessToken", created.getAccessToken());
+    }
+
+    private Long userIdByUsername(String username) {
+        return userRepo.findByUsername(username).orElseThrow().getId();
+    }
+
+    private Long createMembership(Long userId, Long masterId, Long brandId, Long locationId) {
+        UserMembership m = new UserMembership();
+        m.setUser(userRepo.findById(userId).orElseThrow());
+        m.setMaster(masterRepo.findById(masterId).orElseThrow());
+        if (brandId != null) m.setBrand(brandRepo.findById(brandId).orElseThrow());
+        if (locationId != null) m.setPickupPoint(pickupRepo.findById(locationId).orElseThrow());
+        return membershipRepo.save(m).getId();
+    }
+
+    @BeforeEach
+    void setup() {
+    }
+
+    @Test
+    @DisplayName("context/switch success returns accessToken with context claims")
+    void contextSwitch_Success() throws Exception {
+        Cookie authCookie = registerAndLogin("ctx-user");
+        MasterAccount m = masterRepo.save(MasterAccount.builder().name("M1").status("ACTIVE").build());
+        Long userId = userIdByUsername("ctx-user");
+        Long membershipId = createMembership(userId, m.getId(), null, null);
+
+        ContextSwitchRequest req = new ContextSwitchRequest();
+        req.setMembershipId(membershipId);
+
+        MvcResult res = mockMvc.perform(post("/auth/v1/context/switch")
+                        .cookie(authCookie)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(req)))
+                .andExpect(status().isOk())
+                .andReturn();
+        String json = res.getResponse().getContentAsString();
+        assertThat(json).contains("accessToken");
+    }
+
+    @Test
+    @DisplayName("context/switch without membershipId -> 400")
+    void contextSwitch_NoMembershipId_BadRequest() throws Exception {
+        Cookie authCookie = registerAndLogin("ctx-user2");
+        ContextSwitchRequest req = new ContextSwitchRequest();
+        mockMvc.perform(post("/auth/v1/context/switch")
+                        .cookie(authCookie)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(req)))
+                .andExpect(status().isBadRequest());
+    }
+
+    @Test
+    @DisplayName("context/switch membership not belongs to user -> 400")
+    void contextSwitch_MembershipForeign_BadRequest() throws Exception {
+        Cookie authCookie = registerAndLogin("u1");
+        Cookie otherAuth = registerAndLogin("u2");
+        MasterAccount m = masterRepo.save(MasterAccount.builder().name("M1").status("ACTIVE").build());
+        Long user1 = userIdByUsername("u1");
+        Long user2 = userIdByUsername("u2");
+        Long membershipOfUser2 = createMembership(user2, m.getId(), null, null);
+
+        ContextSwitchRequest req = new ContextSwitchRequest();
+        req.setMembershipId(membershipOfUser2);
+        mockMvc.perform(post("/auth/v1/context/switch")
+                        .cookie(authCookie) // trying with user1
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(req)))
+                .andExpect(status().isBadRequest());
+    }
+
+    @Test
+    @DisplayName("context/switch override brand/location mismatch -> 400")
+    void contextSwitch_OverrideMismatch_BadRequest() throws Exception {
+        Cookie authCookie = registerAndLogin("u3");
+        MasterAccount m = masterRepo.save(MasterAccount.builder().name("M1").status("ACTIVE").build());
+        // membership with specific brand/location
+        Brand b1 = brandRepo.save(Brand.builder().name("B1").organizationName("Org1").master(m).build());
+        PickupPoint p1 = pickupRepo.save(PickupPoint.builder().brand(b1).name("P1").address("A").latitude(new BigDecimal("1.0")).longitude(new BigDecimal("2.0")).active(true).build());
+        Long userId = userIdByUsername("u3");
+        Long membershipId = createMembership(userId, m.getId(), b1.getId(), p1.getId());
+
+        // create another brand/location to pass as override mismatch
+        Brand b2 = brandRepo.save(Brand.builder().name("B2").organizationName("Org2").master(m).build());
+        PickupPoint p2 = pickupRepo.save(PickupPoint.builder().brand(b2).name("P2").address("A2").latitude(new BigDecimal("3.0")).longitude(new BigDecimal("4.0")).active(true).build());
+
+        ContextSwitchRequest req = new ContextSwitchRequest();
+        req.setMembershipId(membershipId);
+        req.setBrandId(b2.getId()); // mismatch
+        req.setLocationId(p2.getId()); // mismatch
+
+        mockMvc.perform(post("/auth/v1/context/switch")
+                        .cookie(authCookie)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(req)))
+                .andExpect(status().isBadRequest());
+    }
+}

--- a/src/test/java/kirillzhdanov/identityservice/controller/TenantEnforcementIntegrationTest.java
+++ b/src/test/java/kirillzhdanov/identityservice/controller/TenantEnforcementIntegrationTest.java
@@ -1,0 +1,111 @@
+package kirillzhdanov.identityservice.controller;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import jakarta.servlet.http.Cookie;
+import kirillzhdanov.identityservice.config.IntegrationTestBase;
+import kirillzhdanov.identityservice.dto.ContextSwitchRequest;
+import kirillzhdanov.identityservice.dto.UserRegistrationRequest;
+import kirillzhdanov.identityservice.dto.UserResponse;
+import kirillzhdanov.identityservice.model.Role;
+import kirillzhdanov.identityservice.model.master.MasterAccount;
+import kirillzhdanov.identityservice.model.master.UserMembership;
+import kirillzhdanov.identityservice.repository.UserRepository;
+import kirillzhdanov.identityservice.repository.master.MasterAccountRepository;
+import kirillzhdanov.identityservice.repository.master.UserMembershipRepository;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.http.MediaType;
+import org.springframework.test.annotation.DirtiesContext;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.MvcResult;
+
+import java.util.HashSet;
+import java.util.Set;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@AutoConfigureMockMvc
+@DirtiesContext(classMode = DirtiesContext.ClassMode.AFTER_EACH_TEST_METHOD)
+public class TenantEnforcementIntegrationTest extends IntegrationTestBase {
+
+    @Autowired
+    private MockMvc mockMvc;
+    @Autowired
+    private ObjectMapper objectMapper;
+    @Autowired
+    private MasterAccountRepository masterRepo;
+    @Autowired
+    private UserMembershipRepository membershipRepo;
+    @Autowired
+    private UserRepository userRepo;
+
+    private Cookie registerAndLogin(String username) throws Exception {
+        UserRegistrationRequest req = new UserRegistrationRequest();
+        req.setUsername(username);
+        req.setPassword("Password123!");
+        Set<Role.RoleName> roles = new HashSet<>();
+        roles.add(Role.RoleName.USER);
+        req.setRoleNames(roles);
+        MvcResult res = mockMvc
+                .perform(post("/auth/v1/register")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(req)))
+                .andExpect(status().isCreated())
+                .andReturn();
+        UserResponse created = objectMapper.readValue(res.getResponse().getContentAsString(), UserResponse.class);
+        assertThat(created.getAccessToken()).isNotBlank();
+        return new Cookie("accessToken", created.getAccessToken());
+    }
+
+    @Test
+    @DisplayName("Public endpoints pass without context")
+    void publicEndpoints_NoContext_Ok() throws Exception {
+        mockMvc.perform(get("/status")).andExpect(status().isOk());
+    }
+
+    @Test
+    @DisplayName("Protected endpoint without auth -> 401")
+    void protected_NoAuth_Unauthorized() throws Exception {
+        mockMvc.perform(get("/auth/v1/brands"))
+                .andExpect(status().isUnauthorized());
+    }
+
+    @Test
+    @DisplayName("Protected endpoint with auth but no context -> 403")
+    void protected_Auth_NoContext_Forbidden() throws Exception {
+        Cookie authCookie = registerAndLogin("enf-user");
+        mockMvc.perform(get("/auth/v1/brands").cookie(authCookie))
+                .andExpect(status().isForbidden());
+    }
+
+    @Test
+    @DisplayName("Protected endpoint with auth and context -> 200")
+    void protected_Auth_WithContext_Ok() throws Exception {
+        Cookie authCookie = registerAndLogin("enf-user2");
+        // prepare membership
+        MasterAccount m = masterRepo.save(MasterAccount.builder().name("M1").status("ACTIVE").build());
+        Long userId = userRepo.findByUsername("enf-user2").orElseThrow().getId();
+        UserMembership mem = new UserMembership();
+        mem.setUser(userRepo.findById(userId).orElseThrow());
+        mem.setMaster(m);
+        Long membershipId = membershipRepo.save(mem).getId();
+
+        ContextSwitchRequest req = new ContextSwitchRequest();
+        req.setMembershipId(membershipId);
+        MvcResult res = mockMvc.perform(post("/auth/v1/context/switch")
+                        .cookie(authCookie)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(req)))
+                .andExpect(status().isOk()).andReturn();
+        String accessToken = objectMapper.readTree(res.getResponse().getContentAsString()).get("accessToken").asText();
+        Cookie ctxCookie = new Cookie("accessToken", accessToken);
+
+        mockMvc.perform(get("/auth/v1/brands").cookie(ctxCookie))
+                .andExpect(status().isOk());
+    }
+}


### PR DESCRIPTION
# Описание изменений

- __[JWT клеймы контекста]__
    - Добавлен перегруженный генератор токена [JwtUtils.generateAccessToken(userDetails, membershipId, masterId, brandId, locationId)](cci:1://file:///C:/Users/RillG/IdeaProjects/TenderBotStoreIdentityService/src/main/java/kirillzhdanov/identityservice/security/JwtUtils.java:106:1-126:2) для включения контекстных клеймов.
    - Добавлены экстракторы: [extractMembershipId()](cci:1://file:///C:/Users/RillG/IdeaProjects/TenderBotStoreIdentityService/src/main/java/kirillzhdanov/identityservice/security/JwtUtils.java:192:1-197:5), [extractMasterIdClaim()](cci:1://file:///C:/Users/RillG/IdeaProjects/TenderBotStoreIdentityService/src/main/java/kirillzhdanov/identityservice/security/JwtUtils.java:199:4-204:5), [extractBrandIdClaim()](cci:1://file:///C:/Users/RillG/IdeaProjects/TenderBotStoreIdentityService/src/main/java/kirillzhdanov/identityservice/security/JwtUtils.java:206:4-211:5), [extractLocationIdClaim()](cci:1://file:///C:/Users/RillG/IdeaProjects/TenderBotStoreIdentityService/src/main/java/kirillzhdanov/identityservice/security/JwtUtils.java:213:4-218:5) в [JwtUtils](cci:2://file:///C:/Users/RillG/IdeaProjects/TenderBotStoreIdentityService/src/main/java/kirillzhdanov/identityservice/security/JwtUtils.java:22:0-210:1).

- __[Аутентификация и TenantContext]__
    - В [JwtAuthenticator](cci:2://file:///C:/Users/RillG/IdeaProjects/TenderBotStoreIdentityService/src/main/java/kirillzhdanov/identityservice/security/JwtAuthenticator.java:23:0-178:1) после успешной аутентификации токена наполняется [TenantContext](cci:2://file:///C:/Users/RillG/IdeaProjects/TenderBotStoreIdentityService/src/main/java/kirillzhdanov/identityservice/tenant/TenantContext.java:2:0-25:1) клеймами из JWT.
    - Гарантирована корректная установка [SecurityContext](cci:1://file:///C:/Users/RillG/IdeaProjects/TenderBotStoreIdentityService/src/main/java/kirillzhdanov/identityservice/security/JwtAuthenticator.java:168:1-174:2) и наполнение контекста запроса.

- __[Глобальное принудительное требование контекста]__
    - Новый фильтр `tenant/ContextEnforcementFilter`: возвращает 403 для аутентифицированных защищённых запросов без `masterId` в [TenantContext](cci:2://file:///C:/Users/RillG/IdeaProjects/TenderBotStoreIdentityService/src/main/java/kirillzhdanov/identityservice/tenant/TenantContext.java:2:0-25:1).
    - Вайтлист публичных и служебных маршрутов:
        - `/auth/v1/login`, `/auth/v1/register`, `/auth/v1/refresh`, `/auth/v1/checkUsername`, `/auth/v1/context/switch`, `/auth/v1/revoke`, `/auth/v1/revoke-all`, `/auth/v1/logout`, `/auth/v1/logout/all`
        - `/user/v1/**`, `/public/**`, `/menu/**`, `/notifications/longpoll`, Swagger/OpenAPI, `/status`.

- __[Dev-only X-Master-Id]__
    - `tenant/TenantContextFilter` подключается ТОЛЬКО в профиле `dev`. В проде контекст берется исключительно из JWT.
    - Изменено в [SecurityConfig](cci:2://file:///C:/Users/RillG/IdeaProjects/TenderBotStoreIdentityService/src/main/java/kirillzhdanov/identityservice/security/SecurityConfig.java:20:0-115:1): условная регистрация `TenantContextFilter` по `Environment`, порядок фильтров:
        - prod: [JwtAuthenticationFilter](cci:2://file:///C:/Users/RillG/IdeaProjects/TenderBotStoreIdentityService/src/main/java/kirillzhdanov/identityservice/security/JwtAuthenticationFilter.java:21:0-66:1) → [ContextEnforcementFilter](cci:2://file:///C:/Users/RillG/IdeaProjects/TenderBotStoreIdentityService/src/main/java/kirillzhdanov/identityservice/tenant/ContextEnforcementFilter.java:19:0-73:1)
        - dev: [JwtAuthenticationFilter](cci:2://file:///C:/Users/RillG/IdeaProjects/TenderBotStoreIdentityService/src/main/java/kirillzhdanov/identityservice/security/JwtAuthenticationFilter.java:21:0-66:1) → `TenantContextFilter` → [ContextEnforcementFilter](cci:2://file:///C:/Users/RillG/IdeaProjects/TenderBotStoreIdentityService/src/main/java/kirillzhdanov/identityservice/tenant/ContextEnforcementFilter.java:19:0-73:1)

- __[Контроллер переключения контекста]__
    - Добавлен [ContextController](cci:2://file:///C:/Users/RillG/IdeaProjects/TenderBotStoreIdentityService/src/main/java/kirillzhdanov/identityservice/controller/ContextController.java:21:0-66:1) с `POST /auth/v1/context/switch`.
    - DTO: [ContextSwitchRequest](cci:2://file:///C:/Users/RillG/IdeaProjects/TenderBotStoreIdentityService/src/main/java/kirillzhdanov/identityservice/dto/ContextSwitchRequest.java:4:0-9:1), [ContextSwitchResponse](cci:2://file:///C:/Users/RillG/IdeaProjects/TenderBotStoreIdentityService/src/main/java/kirillzhdanov/identityservice/dto/ContextSwitchResponse.java:5:0-9:1).
    - Валидация: `membershipId` обязателен и должен принадлежать текущему пользователю; опциональные `brandId/locationId` должны совпадать с membership, иначе 400.

- __[Тесты]__
    - [ContextControllerIntegrationTest](cci:2://file:///C:/Users/RillG/IdeaProjects/TenderBotStoreIdentityService/src/test/java/kirillzhdanov/identityservice/controller/ContextControllerIntegrationTest.java:36:0-162:1):
        - 200 при валидном `membershipId`, выдача `accessToken`.
        - 400 без `membershipId`.
        - 400 при попытке использовать чужой membership.
        - 400 при mismatch override `brandId/locationId`.
    - [TenantEnforcementIntegrationTest](cci:2://file:///C:/Users/RillG/IdeaProjects/TenderBotStoreIdentityService/src/test/java/kirillzhdanov/identityservice/controller/TenantEnforcementIntegrationTest.java:30:0-104:1):
        - Публичные маршруты — без контекста OK.
        - Защищённый маршрут без аутентификации — 401.
        - Аутентифицирован без контекста — 403.
        - Аутентифицирован с контекстом из `context/switch` — 200.
    - [BrandControllerJwtContextIntegrationTest](cci:2://file:///C:/Users/RillG/IdeaProjects/TenderBotStoreIdentityService/src/test/java/kirillzhdanov/identityservice/controller/BrandControllerJwtContextIntegrationTest.java:34:0-116:1):
        - Изоляция брендов по `master` при JWT‑контексте: в M1 видны только свои бренды, в M2 — не видны.
    - Актуализировано: [BrandControllerContextIntegrationTest](cci:2://file:///C:/Users/RillG/IdeaProjects/TenderBotStoreIdentityService/src/test/java/kirillzhdanov/identityservice/controller/BrandControllerContextIntegrationTest.java:15:0-23:38) помечен `@ActiveProfiles("dev")` для использования `X-Master-Id` в dev‑профиле.
    - Все тесты зеленые: 192/0/0.

- __[Документация]__
    - Обновлён [README.md](cci:7://file:///C:/Users/RillG/IdeaProjects/TenderBotStoreIdentityService/README.md:0:0-0:0): раздел “Tenant Context (JWT) и контекст переключения” с примером запроса к `/auth/v1/context/switch`, рекомендацией фронту (логин → выбор контекста → switch → использование нового accessToken), и пометкой, что `X-Master-Id` — только для dev.

# Мотивация и результат
- Реализована полная передача контекста арендатора в JWT.
- Глобально enforce-ится контекст для защищённых операций, обеспечивается изоляция данных между мастерами/брендами/локациями.
- Совместимость с текущими auth/user эндпоинтами сохранена.
- Добавлены интеграционные тесты, покрывающие новые сценарии и регресс‑моменты — все тесты проходят.

# Влияние на деплой/конфигурацию
- Для локальной разработки установить профиль `dev` если требуется поддержка `X-Master-Id`:
    - `SPRING_PROFILES_ACTIVE=dev`
- В проде профиль `dev` НЕ включать — контекст только из JWT.

# Как проверить
- Локально: зарегистрировать пользователя → вызвать `/auth/v1/context/switch` с собственным `membershipId` → использовать выданный `accessToken` для `GET/POST /auth/v1/brands` без `X-Master-Id`.
- Запустить тесты:
    - `mvn clean test` → ожидаемо “Tests run: 192, Failures: 0, Errors: 0, Skipped: 0”.