### PR TITLE
B2-TS-3: Иразрешить доступ кухне (COOK) и запретить админку/финансы для не-ADMIN/OWNER.

### DIFF
--- a/src/main/java/kirillzhdanov/identityservice/controller/KitchenController.java
+++ b/src/main/java/kirillzhdanov/identityservice/controller/KitchenController.java
@@ -1,0 +1,23 @@
+package kirillzhdanov.identityservice.controller;
+
+import kirillzhdanov.identityservice.security.RbacGuard;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/kitchen/v1")
+@RequiredArgsConstructor
+public class KitchenController {
+
+    private final RbacGuard rbacGuard;
+
+    @GetMapping("/ping")
+    public ResponseEntity<String> ping() {
+        // Allow only COOK role
+        rbacGuard.requireCook();
+        return ResponseEntity.ok("OK");
+    }
+}

--- a/src/main/java/kirillzhdanov/identityservice/controller/admin/AdminOrderController.java
+++ b/src/main/java/kirillzhdanov/identityservice/controller/admin/AdminOrderController.java
@@ -1,6 +1,7 @@
 package kirillzhdanov.identityservice.controller.admin;
 
 import kirillzhdanov.identityservice.dto.order.OrderDto;
+import kirillzhdanov.identityservice.security.RbacGuard;
 import kirillzhdanov.identityservice.service.admin.OrderAdminService;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;
@@ -18,9 +19,11 @@ import org.springframework.web.bind.annotation.RestController;
 public class AdminOrderController {
 
     private final OrderAdminService orderAdminService;
+    private final RbacGuard rbacGuard;
 
-    public AdminOrderController(OrderAdminService orderAdminService) {
+    public AdminOrderController(OrderAdminService orderAdminService, RbacGuard rbacGuard) {
         this.orderAdminService = orderAdminService;
+        this.rbacGuard = rbacGuard;
     }
 
     @GetMapping
@@ -32,6 +35,8 @@ public class AdminOrderController {
             @RequestParam(required = false) String dateFrom,
             @RequestParam(required = false) String dateTo
     ) {
+        // Enforce membership-based RBAC: only OWNER/ADMIN in current tenant context
+        rbacGuard.requireOwnerOrAdmin();
         Pageable pageable = PageRequest.of(Math.max(0, page), Math.max(1, size));
         Page<OrderDto> result = orderAdminService.findOrders(pageable, search, brandId, dateFrom, dateTo);
         return ResponseEntity.ok(result);

--- a/src/test/java/kirillzhdanov/identityservice/controller/KitchenAccessIntegrationTest.java
+++ b/src/test/java/kirillzhdanov/identityservice/controller/KitchenAccessIntegrationTest.java
@@ -1,0 +1,65 @@
+package kirillzhdanov.identityservice.controller;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import jakarta.servlet.http.Cookie;
+import kirillzhdanov.identityservice.config.IntegrationTestBase;
+import kirillzhdanov.identityservice.model.master.RoleMembership;
+import kirillzhdanov.identityservice.testutil.MembershipFixtures;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.servlet.MockMvc;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@AutoConfigureMockMvc
+public class KitchenAccessIntegrationTest extends IntegrationTestBase {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @Autowired
+    private ObjectMapper objectMapper;
+
+    @Autowired
+    private MembershipFixtures fixtures;
+
+    @Test
+    @DisplayName("B2-TS-3: COOK can access kitchen; admin area forbidden for COOK")
+    void cook_access_and_admin_forbidden() throws Exception {
+        String username = "cook-user-" + System.nanoTime();
+
+        // Register and obtain initial token
+        Cookie login = fixtures.registerAndLogin(username);
+        assertThat(login.getValue()).isNotBlank();
+
+        // Prepare COOK membership and switch context to get COOK token
+        var ctx = fixtures.prepareRoleMembership(login, username, RoleMembership.COOK);
+        Long masterId = ctx.masterId();
+        Cookie cookToken = ctx.cookie();
+        assertThat(cookToken.getValue()).isNotBlank();
+
+        // Kitchen allowed for COOK
+        mockMvc.perform(get("/kitchen/v1/ping")
+                        .header("X-Brand-Id", "1")
+                        .header("X-Master-Id", String.valueOf(masterId))
+                        .cookie(cookToken)
+                        .header("Authorization", "Bearer " + cookToken.getValue())
+                        .accept(MediaType.TEXT_PLAIN))
+                .andExpect(status().isOk())
+                .andExpect(content().string("OK"));
+
+        // Admin endpoint forbidden for COOK
+        mockMvc.perform(get("/admin/v1/orders")
+                        .header("X-Brand-Id", "1")
+                        .header("X-Master-Id", String.valueOf(masterId))
+                        .cookie(cookToken)
+                        .header("Authorization", "Bearer " + cookToken.getValue()))
+                .andExpect(status().isForbidden());
+    }
+}


### PR DESCRIPTION
# Commit Title
feat(b2-ts-3): разрешить доступ кухне (COOK) и запретить админку/финансы для не-ADMIN/OWNER

# Commit Description
- **[kitchen]** Добавлен [KitchenController](cci:2://file:///C:/Users/RillG/IdeaProjects/TenderBotStoreIdentityService/src/main/java/kirillzhdanov/identityservice/controller/KitchenController.java:9:0-22:1) с эндпоинтом `GET /kitchen/v1/ping`, защищённым через [RbacGuard.requireCook()](cci:1://file:///C:/Users/RillG/IdeaProjects/TenderBotStoreIdentityService/src/main/java/kirillzhdanov/identityservice/security/RbacGuard.java:44:4-49:5) — доступ только для роли `COOK`.
- **[admin guard]** Ужесточён доступ к админ-эндпоинту:
    - В `AdminOrderController#getOrders()` добавлено [rbacGuard.requireOwnerOrAdmin()](cci:1://file:///C:/Users/RillG/IdeaProjects/TenderBotStoreIdentityService/src/main/java/kirillzhdanov/identityservice/security/RbacGuard.java:30:4-35:5) для RBAC по membership-контексту (OWNER/ADMIN).
- **[tests]** Добавлен интеграционный тест [KitchenAccessIntegrationTest](cci:2://file:///C:/Users/RillG/IdeaProjects/TenderBotStoreIdentityService/src/test/java/kirillzhdanov/identityservice/controller/KitchenAccessIntegrationTest.java:19:0-64:1):
    - Проверяет, что `COOK` имеет доступ к `/kitchen/v1/ping` (200 OK).
    - Проверяет, что `COOK` не имеет доступа к `/admin/v1/orders` (403 Forbidden).
    - В тестах используются заголовки `X-Brand-Id` и `X-Master-Id` для удовлетворения [ContextEnforcementFilter](cci:2://file:///C:/Users/RillG/IdeaProjects/TenderBotStoreIdentityService/src/main/java/kirillzhdanov/identityservice/tenant/ContextEnforcementFilter.java:19:0-84:1).
- **[stability]** Ранее приведены к порядку тесты авторизации ([AuthWhoamiIntegrationTest](cci:2://file:///C:/Users/RillG/IdeaProjects/TenderBotStoreIdentityService/src/test/java/kirillzhdanov/identityservice/controller/AuthWhoamiIntegrationTest.java:22:0-104:1)) и фикстуры ([MembershipFixtures](cci:2://file:///C:/Users/RillG/IdeaProjects/TenderBotStoreIdentityService/src/test/java/kirillzhdanov/identityservice/testutil/MembershipFixtures.java:38:0-209:1)) с обязательными заголовками `X-Brand-Id`/`X-Master-Id`.
- **[seeding]** В тестовой базе гарантируется наличие бренда `id=1` для `X-Brand-Id`.

# Affected Files
- [src/main/java/kirillzhdanov/identityservice/controller/KitchenController.java](cci:7://file:///C:/Users/RillG/IdeaProjects/TenderBotStoreIdentityService/src/main/java/kirillzhdanov/identityservice/controller/KitchenController.java:0:0-0:0) (new)
- [src/main/java/kirillzhdanov/identityservice/controller/admin/AdminOrderController.java](cci:7://file:///C:/Users/RillG/IdeaProjects/TenderBotStoreIdentityService/src/main/java/kirillzhdanov/identityservice/controller/admin/AdminOrderController.java:0:0-0:0) (RBAC через [RbacGuard.requireOwnerOrAdmin()](cci:1://file:///C:/Users/RillG/IdeaProjects/TenderBotStoreIdentityService/src/main/java/kirillzhdanov/identityservice/security/RbacGuard.java:30:4-35:5))
- [src/test/java/kirillzhdanov/identityservice/controller/KitchenAccessIntegrationTest.java](cci:7://file:///C:/Users/RillG/IdeaProjects/TenderBotStoreIdentityService/src/test/java/kirillzhdanov/identityservice/controller/KitchenAccessIntegrationTest.java:0:0-0:0) (new)
- [src/test/java/kirillzhdanov/identityservice/controller/AuthWhoamiIntegrationTest.java](cci:7://file:///C:/Users/RillG/IdeaProjects/TenderBotStoreIdentityService/src/test/java/kirillzhdanov/identityservice/controller/AuthWhoamiIntegrationTest.java:0:0-0:0) (заголовки для контекста)
- [src/test/java/kirillzhdanov/identityservice/testutil/MembershipFixtures.java](cci:7://file:///C:/Users/RillG/IdeaProjects/TenderBotStoreIdentityService/src/test/java/kirillzhdanov/identityservice/testutil/MembershipFixtures.java:0:0-0:0) (заголовки для контекста)
- [src/test/java/kirillzhdanov/identityservice/config/IntegrationTestBase.java](cci:7://file:///C:/Users/RillG/IdeaProjects/TenderBotStoreIdentityService/src/test/java/kirillzhdanov/identityservice/config/IntegrationTestBase.java:0:0-0:0) (сид бренда для тестов)

# Rationale
- Соответствие задаче B2-TS-3: “Разрешить кухню; запретить финансы/админку.” В рамках текущего функционала кухня представлена минимальным эндпоинтом, а доступ в админку ограничен ролями OWNER/ADMIN по membership-контексту.

# How to Test
- Запустить интеграционные тесты:
  ```
  mvn -q -Dtest="*KitchenAccessIntegrationTest" test
  ```
- Ожидаемо:
    - `GET /kitchen/v1/ping` под токеном `COOK` → 200 OK
    - `GET /admin/v1/orders` под токеном `COOK` → 403 Forbidden

# Notes
- Заголовки `X-Brand-Id` и `X-Master-Id` обязательны в dev-профиле из-за [ContextEnforcementFilter](cci:2://file:///C:/Users/RillG/IdeaProjects/TenderBotStoreIdentityService/src/main/java/kirillzhdanov/identityservice/tenant/ContextEnforcementFilter.java:19:0-84:1) + [TenantContextFilter](cci:2://file:///C:/Users/RillG/IdeaProjects/TenderBotStoreIdentityService/src/main/java/kirillzhdanov/identityservice/tenant/TenantContextFilter.java:15:0-37:1).
- В будущих задачах можно расширить набор кухонных эндпоинтов и добавить тесты для “финансов”, когда появится соответствующий функционал.