### PR TITLE
корректный онбординг владельцев, автосоздание Master, устойчивый контекст, изоляция брендов по членствам и обновление тестов

### DIFF
--- a/Front/src/views/AdminView.vue
+++ b/Front/src/views/AdminView.vue
@@ -468,6 +468,14 @@ const canSeeAdminLinks = computed(() => {
   return roles.includes('ADMIN') || roles.includes('OWNER');
 });
 
+// OWNER без членств: разрешаем и подсказываем создать бренд
+const isFirstOwnerWithoutMembership = computed(() => {
+  const roles = Array.isArray(authStore.roles) ? authStore.roles : [];
+  const isOwner = roles.includes('OWNER');
+  const hasMemberships = Array.isArray(authStore.memberships) && authStore.memberships.length > 0;
+  return isOwner && !hasMemberships;
+});
+
 // Helper function for Russian pluralization
 const formatWord = (count, words) => {
   const cases = [2, 0, 1, 1, 1, 2];
@@ -600,6 +608,19 @@ onMounted(() => {
       }
     }, { root: null, rootMargin: '200px 0px 200px 0px', threshold: 0.1 });
     if (productsSentry.value) observer.observe(productsSentry.value);
+  }
+});
+
+// Авто-открытие модалки создания бренда для нового владельца без членств (один раз)
+onMounted(() => {
+  try {
+    const guardKey = 'auto_open_create_brand_once';
+    const already = localStorage.getItem(guardKey) === '1';
+    if (!already && isFirstOwnerWithoutMembership.value) {
+      showCreateBrandModal.value = true;
+      localStorage.setItem(guardKey, '1');
+    }
+  } catch (_) {
   }
 });
 

--- a/src/main/java/kirillzhdanov/identityservice/repository/BrandRepository.java
+++ b/src/main/java/kirillzhdanov/identityservice/repository/BrandRepository.java
@@ -15,4 +15,6 @@ public interface BrandRepository extends JpaRepository<Brand, Long> {
 	java.util.Optional<Brand> findByIdAndMaster_Id(Long id, Long masterId);
 
 	boolean existsByNameAndMaster_Id(String name, Long masterId);
+
+	java.util.List<Brand> findByIdIn(java.util.Collection<Long> ids);
 }

--- a/src/main/java/kirillzhdanov/identityservice/service/MasterAccountService.java
+++ b/src/main/java/kirillzhdanov/identityservice/service/MasterAccountService.java
@@ -1,0 +1,38 @@
+package kirillzhdanov.identityservice.service;
+
+import kirillzhdanov.identityservice.exception.ResourceNotFoundException;
+import kirillzhdanov.identityservice.model.master.MasterAccount;
+import kirillzhdanov.identityservice.repository.UserRepository;
+import kirillzhdanov.identityservice.repository.master.MasterAccountRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Propagation;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+public class MasterAccountService {
+
+    private final MasterAccountRepository masterAccountRepository;
+    private final UserRepository userRepository;
+
+    @Transactional(propagation = Propagation.REQUIRES_NEW)
+    public Long resolveOrCreateMasterIdForCurrentUser() {
+        Authentication auth = SecurityContextHolder.getContext().getAuthentication();
+        if (auth == null || !auth.isAuthenticated()) {
+            throw new ResourceNotFoundException("Not authenticated");
+        }
+        String username = auth.getName();
+        // ensure user exists
+        userRepository.findByUsername(username)
+                .orElseThrow(() -> new ResourceNotFoundException("User not found: " + username));
+        MasterAccount master = masterAccountRepository.findByName(username)
+                .orElseGet(() -> masterAccountRepository.save(MasterAccount.builder()
+                        .name(username)
+                        .status("ACTIVE")
+                        .build()));
+        return master.getId();
+    }
+}

--- a/src/main/java/kirillzhdanov/identityservice/tenant/ContextEnforcementFilter.java
+++ b/src/main/java/kirillzhdanov/identityservice/tenant/ContextEnforcementFilter.java
@@ -61,6 +61,8 @@ public class ContextEnforcementFilter extends OncePerRequestFilter {
         if (HttpMethod.OPTIONS.matches(request.getMethod())) return true;
         // Allow first-time brand creation without tenant context
         if (HttpMethod.POST.matches(request.getMethod()) && "/auth/v1/brands".equals(uri)) return true;
+        // Allow listing brands for authenticated users without tenant context (fallback master will be derived)
+        if (HttpMethod.GET.matches(request.getMethod()) && "/auth/v1/brands".equals(uri)) return true;
         for (String p : PUBLIC_PREFIXES) {
             if (uri.startsWith(p)) return true;
         }

--- a/src/test/java/kirillzhdanov/identityservice/controller/TenantEnforcementIntegrationTest.java
+++ b/src/test/java/kirillzhdanov/identityservice/controller/TenantEnforcementIntegrationTest.java
@@ -76,11 +76,11 @@ public class TenantEnforcementIntegrationTest extends IntegrationTestBase {
     }
 
     @Test
-    @DisplayName("Protected endpoint with auth but no context -> 403")
-    void protected_Auth_NoContext_Forbidden() throws Exception {
+    @DisplayName("Protected brands endpoint with auth but no context -> 200 (master auto-derived)")
+    void protected_Auth_NoContext_AllowsBrands() throws Exception {
         Cookie authCookie = registerAndLogin("enf-user");
         mockMvc.perform(get("/auth/v1/brands").cookie(authCookie))
-                .andExpect(status().isForbidden());
+                .andExpect(status().isOk());
     }
 
     @Test


### PR DESCRIPTION
# Подробное описание PR

## Что и зачем

- **[Проблема]**
    - Новый пользователь (OWNER без членств) ловил 403/ошибки контекста и не мог создать первый бренд.
    - После перезагрузки терялся контекст (master/brand/membership) → 401/403.
    - `GET /auth/v1/brands` возвращал бренды не по правам пользователя.
    - Фронтовые и серверные тесты падали из‑за новой логики.

- **[Цели]**
    - Разблокировать создание первого бренда для новых пользователей.
    - Устойчиво сохранять/восстанавливать контекст на фронте.
    - Обеспечить безопасность: показывать только те бренды, где у пользователя есть роль ADMIN/OWNER и в пределах текущего master.
    - Привести тесты в соответствие с новой логикой.

## Бэкенд

- **[Разрешение брендов без X‑Master-Id, но только для авторизации]**
    - [src/main/java/kirillzhdanov/identityservice/tenant/ContextEnforcementFilter.java](cci:7://file:///C:/Users/RillG/IdeaProjects/TenderBotStoreIdentityService/src/main/java/kirillzhdanov/identityservice/tenant/ContextEnforcementFilter.java:0:0-0:0)
        - Добавлено исключение для `GET /auth/v1/brands`, как и ранее для `POST /auth/v1/brands`. Это устраняет 403 при первом входе без контекста, но запрос всё равно требует аутентификацию.

- **[Автосоздание MasterAccount при необходимости]**
    - [src/main/java/kirillzhdanov/identityservice/service/MasterAccountService.java](cci:7://file:///C:/Users/RillG/IdeaProjects/TenderBotStoreIdentityService/src/main/java/kirillzhdanov/identityservice/service/MasterAccountService.java:0:0-0:0) (новый)
        - Метод [resolveOrCreateMasterIdForCurrentUser()](cci:1://file:///C:/Users/RillG/IdeaProjects/TenderBotStoreIdentityService/src/main/java/kirillzhdanov/identityservice/service/BrandService.java:74:4-90:5) с `@Transactional(REQUIRES_NEW)` создаёт Master вне read‑only транзакций.
    - [src/main/java/kirillzhdanov/identityservice/service/AuthService.java](cci:7://file:///C:/Users/RillG/IdeaProjects/TenderBotStoreIdentityService/src/main/java/kirillzhdanov/identityservice/service/AuthService.java:0:0-0:0)
        - В [registerUser()](cci:1://file:///C:/Users/RillG/IdeaProjects/TenderBotStoreIdentityService/src/main/java/kirillzhdanov/identityservice/service/AuthService.java:64:4-150:5) после сохранения пользователя гарантируем наличие `MasterAccount` (если нет — создаём).
    - [src/main/java/kirillzhdanov/identityservice/service/BrandService.java](cci:7://file:///C:/Users/RillG/IdeaProjects/TenderBotStoreIdentityService/src/main/java/kirillzhdanov/identityservice/service/BrandService.java:0:0-0:0)
        - Для операций создания бренда используется fallback на мастер текущего пользователя (при отсутствии [TenantContext](cci:2://file:///C:/Users/RillG/IdeaProjects/TenderBotStoreIdentityService/src/main/java/kirillzhdanov/identityservice/tenant/TenantContext.java:4:0-73:1)).

- **[Безопасная выдача брендов пользователю]**
    - [src/main/java/kirillzhdanov/identityservice/service/BrandService.java](cci:7://file:///C:/Users/RillG/IdeaProjects/TenderBotStoreIdentityService/src/main/java/kirillzhdanov/identityservice/service/BrandService.java:0:0-0:0)
        - [getMyBrands()](cci:1://file:///C:/Users/RillG/IdeaProjects/TenderBotStoreIdentityService/src/main/java/kirillzhdanov/identityservice/service/BrandService.java:61:4-97:5) полностью переписан:
            - Возвращает только те бренды, в которых у пользователя есть активное членство со статусом `ACTIVE` и ролями `ADMIN` или `OWNER`.
            - Если в [TenantContext](cci:2://file:///C:/Users/RillG/IdeaProjects/TenderBotStoreIdentityService/src/main/java/kirillzhdanov/identityservice/tenant/TenantContext.java:4:0-73:1) есть `masterId`, список дополнительно фильтруется по нему.
            - Если `masterId` отсутствует — возвращается пустой список (новый пользователь видит пусто, но может создать свой бренд).
    - [src/main/java/kirillzhdanov/identityservice/repository/BrandRepository.java](cci:7://file:///C:/Users/RillG/IdeaProjects/TenderBotStoreIdentityService/src/main/java/kirillzhdanov/identityservice/repository/BrandRepository.java:0:0-0:0)
        - Добавлен метод [findByIdIn(Collection<Long> ids)](cci:1://file:///C:/Users/RillG/IdeaProjects/TenderBotStoreIdentityService/src/main/java/kirillzhdanov/identityservice/repository/BrandRepository.java:18:1-18:66) для выборки брендов по списку из членств.

- **[Контроллер]**
    - [src/main/java/kirillzhdanov/identityservice/controller/BrandController.java](cci:7://file:///C:/Users/RillG/IdeaProjects/TenderBotStoreIdentityService/src/main/java/kirillzhdanov/identityservice/controller/BrandController.java:0:0-0:0)
        - `GET /auth/v1/brands` использует [brandService.getMyBrands()](cci:1://file:///C:/Users/RillG/IdeaProjects/TenderBotStoreIdentityService/src/main/java/kirillzhdanov/identityservice/service/BrandService.java:61:4-97:5) — применяются новые правила выдачи.

## Фронтенд

- **[UX для новых владельцев]**
    - [Front/src/views/AdminView.vue](cci:7://file:///C:/Users/RillG/IdeaProjects/TenderBotStoreIdentityService/Front/src/views/AdminView.vue:0:0-0:0)
        - Кнопка “+ Создать бренд” не зависит от членств (дизейбл только на `loading`).
        - `isFirstOwnerWithoutMembership`: вычисление состояния “OWNER без членств”.
        - Баннер с подсказкой и однократное авто‑открытие модалки создания бренда (guard в `localStorage`).

- **[Стабильный контекст и заголовки]**
    - [Front/src/store/auth.js](cci:7://file:///C:/Users/RillG/IdeaProjects/TenderBotStoreIdentityService/Front/src/store/auth.js:0:0-0:0)
        - Сохраняем `selected_membership_id`, `current_brand_id`, `current_master_id` при выборе контекста.
        - В [restoreSession()](cci:1://file:///C:/Users/RillG/IdeaProjects/TenderBotStoreIdentityService/Front/src/store/auth.js:223:8-272:9):
            - Восстанавливаем сохранённый контекст.
            - Если членство одно — выбираем автоматически.
    - [Front/src/services/api.js](cci:7://file:///C:/Users/RillG/IdeaProjects/TenderBotStoreIdentityService/Front/src/services/api.js:0:0-0:0)
        - Request‑интерцептор стал `async`: ждёт [restoreSession](cci:1://file:///C:/Users/RillG/IdeaProjects/TenderBotStoreIdentityService/Front/src/store/auth.js:223:8-272:9), чтобы корректно добавить `Authorization`.
        - `X-Brand-Id` берётся из `localStorage.current_brand_id`.
        - `X-Master-Id` — из стора, иначе fallback на `localStorage.current_master_id`.
        - Сохранили защиту от шторма и ретраи refresh.

## Тесты

- **[Фронтенд]**
    - [Front/tests/setup.js](cci:7://file:///C:/Users/RillG/IdeaProjects/TenderBotStoreIdentityService/Front/tests/setup.js:0:0-0:0):
        - Полный shim `localStorage`.
        - Глобальный мок `authService`: по умолчанию `refresh` → reject (симулируем отсутствие refresh‑куки). Тесты, где нужен успешный refresh (например, [auth.store.spec.js](cci:7://file:///C:/Users/RillG/IdeaProjects/TenderBotStoreIdentityService/Front/tests/auth.store.spec.js:0:0-0:0)), переопределяют мок локально на resolve.
        - Зарегистрирована глобальная no‑op директива `v-can`.
    - Тесты [routerGuards.spec.js](cci:7://file:///C:/Users/RillG/IdeaProjects/TenderBotStoreIdentityService/Front/tests/routerGuards.spec.js:0:0-0:0), [auth.store.spec.js](cci:7://file:///C:/Users/RillG/IdeaProjects/TenderBotStoreIdentityService/Front/tests/auth.store.spec.js:0:0-0:0) стабилизированы и проходят.

- **[Сервер]**
    - [src/test/java/kirillzhdanov/identityservice/controller/TenantEnforcementIntegrationTest.java](cci:7://file:///C:/Users/RillG/IdeaProjects/TenderBotStoreIdentityService/src/test/java/kirillzhdanov/identityservice/controller/TenantEnforcementIntegrationTest.java:0:0-0:0)
        - Тест `protected_Auth_NoContext_Forbidden` заменён на [protected_Auth_NoContext_AllowsBrands](cci:1://file:///C:/Users/RillG/IdeaProjects/TenderBotStoreIdentityService/src/test/java/kirillzhdanov/identityservice/controller/TenantEnforcementIntegrationTest.java:77:4-83:5) с ожиданием `200 OK` (новая бизнес‑логика).
    - Проблемные тесты, ожидавшие “пусто” при отсутствии корректного контекста, теперь соответствуют логике:
        - Список брендов пуст без `masterId`.
        - При наличии `masterId` — бренды только по членствам и текущему master.
 
## Риски и совместимость

- Разрешение `GET /auth/v1/brands` без `X-Master-Id` безопасно: ответ зависит от аутентификации и текущих членств. Без контекста список пуст, нет утечек чужих брендов.
- Автовыбор единственного членства не блокирует создание нового бренда.

## Затронутые файлы

- Бэкенд:
    - [src/main/java/kirillzhdanov/identityservice/tenant/ContextEnforcementFilter.java](cci:7://file:///C:/Users/RillG/IdeaProjects/TenderBotStoreIdentityService/src/main/java/kirillzhdanov/identityservice/tenant/ContextEnforcementFilter.java:0:0-0:0)
    - [src/main/java/kirillzhdanov/identityservice/service/MasterAccountService.java](cci:7://file:///C:/Users/RillG/IdeaProjects/TenderBotStoreIdentityService/src/main/java/kirillzhdanov/identityservice/service/MasterAccountService.java:0:0-0:0)
    - [src/main/java/kirillzhdanov/identityservice/service/BrandService.java](cci:7://file:///C:/Users/RillG/IdeaProjects/TenderBotStoreIdentityService/src/main/java/kirillzhdanov/identityservice/service/BrandService.java:0:0-0:0)
    - [src/main/java/kirillzhdanov/identityservice/service/AuthService.java](cci:7://file:///C:/Users/RillG/IdeaProjects/TenderBotStoreIdentityService/src/main/java/kirillzhdanov/identityservice/service/AuthService.java:0:0-0:0)
    - [src/main/java/kirillzhdanov/identityservice/repository/BrandRepository.java](cci:7://file:///C:/Users/RillG/IdeaProjects/TenderBotStoreIdentityService/src/main/java/kirillzhdanov/identityservice/repository/BrandRepository.java:0:0-0:0)
    - [src/main/java/kirillzhdanov/identityservice/controller/BrandController.java](cci:7://file:///C:/Users/RillG/IdeaProjects/TenderBotStoreIdentityService/src/main/java/kirillzhdanov/identityservice/controller/BrandController.java:0:0-0:0)
- Фронтенд:
    - [Front/src/views/AdminView.vue](cci:7://file:///C:/Users/RillG/IdeaProjects/TenderBotStoreIdentityService/Front/src/views/AdminView.vue:0:0-0:0)
    - [Front/src/store/auth.js](cci:7://file:///C:/Users/RillG/IdeaProjects/TenderBotStoreIdentityService/Front/src/store/auth.js:0:0-0:0)
    - [Front/src/services/api.js](cci:7://file:///C:/Users/RillG/IdeaProjects/TenderBotStoreIdentityService/Front/src/services/api.js:0:0-0:0)
    - [Front/tests/setup.js](cci:7://file:///C:/Users/RillG/IdeaProjects/TenderBotStoreIdentityService/Front/tests/setup.js:0:0-0:0)
- Тесты:
    - [src/test/java/kirillzhdanov/identityservice/controller/TenantEnforcementIntegrationTest.java](cci:7://file:///C:/Users/RillG/IdeaProjects/TenderBotStoreIdentityService/src/test/java/kirillzhdanov/identityservice/controller/TenantEnforcementIntegrationTest.java:0:0-0:0)
    - Фронтовые тесты (*.spec.js)
 