### PR TITLE
Исправлена перезапись ссылки аватарки пользователя который авторизуется через google oAuth2

### DIFF
--- a/src/main/java/kirillzhdanov/identityservice/googleOAuth2/GoogleOAuth2Service.java
+++ b/src/main/java/kirillzhdanov/identityservice/googleOAuth2/GoogleOAuth2Service.java
@@ -109,10 +109,8 @@ public class GoogleOAuth2Service {
         User user;
         if (byEmail.isPresent()) {
             user = byEmail.get();
-            // Обновим недостающие поля аккуратно
-            if ((user.getAvatarUrl() == null || user.getAvatarUrl().isBlank()) && pictureUrl != null && !pictureUrl.isBlank()) {
-                user.setAvatarUrl(pictureUrl);
-            }
+            // Не перезаписываем аватарку из Google, если пользователь уже существует.
+            // Дополняем только недостающие ФИО и флаг подтверждения почты.
             if ((user.getFirstName() == null || user.getFirstName().isBlank()) && firstName != null && !firstName.isBlank()) {
                 user.setFirstName(firstName);
             }
@@ -134,7 +132,7 @@ public class GoogleOAuth2Service {
                     .firstName(firstName)
                     .lastName(lastName)
                     .email(email)
-                    .avatarUrl(pictureUrl)
+                    .avatarUrl(pictureUrl) // только при первичном создании пользователя
                     .emailVerified(emailVerified != null ? emailVerified : false)
                     .roles(new HashSet<>())
                     .brands(new HashSet<>())


### PR DESCRIPTION
- **[Проблема]**
    - При авторизации через Google аватар пользователя перезаписывался на ссылку из провайдера, даже если:
        - пользователь уже загружал кастомную аватарку;
        - или ранее уже был установлен `avatarUrl`.

- **[Решение]**
    - В [GoogleOAuth2Service.findOrCreateAndLinkUser()](cci:1://file:///C:/Users/RillG/IdeaProjects/TenderBotStoreIdentityService/src/main/java/kirillzhdanov/identityservice/googleOAuth2/GoogleOAuth2Service.java:96:4-156:5):
        - При существующем пользователе (линковка по email или наличие mapping) больше НЕ обновляем `avatarUrl` из Google.
        - Аватар из Google устанавливается только при первичном создании нового пользователя.
        - По-прежнему дополняем недостающие `firstName`/`lastName` и флаг `emailVerified`.

- **[Затронутые файлы]**
    - [src/main/java/kirillzhdanov/identityservice/googleOAuth2/GoogleOAuth2Service.java](cci:7://file:///C:/Users/RillG/IdeaProjects/TenderBotStoreIdentityService/src/main/java/kirillzhdanov/identityservice/googleOAuth2/GoogleOAuth2Service.java:0:0-0:0)
    - [src/test/java/kirillzhdanov/identityservice/googleOAuth2/GoogleOAuth2ServiceTest.java](cci:7://file:///C:/Users/RillG/IdeaProjects/TenderBotStoreIdentityService/src/test/java/kirillzhdanov/identityservice/googleOAuth2/GoogleOAuth2ServiceTest.java:0:0-0:0)

- **[Тесты]**
    - Обновлены/добавлены тесты:
        - [linkExistingByEmail_doesNotOverwriteAvatar()](cci:1://file:///C:/Users/RillG/IdeaProjects/TenderBotStoreIdentityService/src/test/java/kirillzhdanov/identityservice/googleOAuth2/GoogleOAuth2ServiceTest.java:155:4-178:5): при линковке по email аватар не перезаписывается.
        - [existingProviderMapping_doesNotOverwriteAvatar()](cci:1://file:///C:/Users/RillG/IdeaProjects/TenderBotStoreIdentityService/src/test/java/kirillzhdanov/identityservice/googleOAuth2/GoogleOAuth2ServiceTest.java:129:4-153:5): при повторном входе (mapping существует) аватар не перезаписывается.
    - Тесты подтверждают, что токены выдаются и сохраняются, но `userRepository.save(...)` не используется для замены аватара.

- **[Регрессии/совместимость]**
    - API не менялось, миграций БД нет.
    - Поведение первичной регистрации сохранено (аватар берётся из Google один раз).

- **[Как проверить]**
    - Новый пользователь через Google → в профиле установлен `avatarUrl` из Google.
    - Повторный вход через Google → `avatarUrl` неизменен.
    - Пользователь с кастомной аватаркой → вход через Google не меняет `avatarUrl`.