### PR TITLE
B2-DC-3: Пометки в OpenAPI. Пометки RBAC в Swagger и исправлена публикация Wiki (ссылки без .md), обновлён README. Также обновлен ci для документации. И проведена работа с предупреждениями.

### DIFF
--- a/.github/workflows/docs-wiki-pr.yml
+++ b/.github/workflows/docs-wiki-pr.yml
@@ -31,18 +31,41 @@ jobs:
           find wiki -mindepth 1 -maxdepth 1 ! -name '.git' -exec rm -rf {} +
           # Copy markdown sources
           cp -r docs/* wiki/
-          # Set homepage
-          if [ -f docs/index.md ]; then
-            cp docs/index.md wiki/Home.md
+          # Normalize links: convert ")(.md)" links to wiki-style without extension across copied files
+          # This replaces occurrences of ](path.md) with ](path)
+          if command -v sed >/dev/null 2>&1; then
+            find wiki -type f -name "*.md" -print0 | xargs -0 sed -i "s/](\([^)#?]*\)\.md)/](\1)/g"
           fi
-          # Ensure sidebar exists
+          # Generate wiki-friendly Home.md (links without .md extensions)
+          printf '%s\n' \
+            '# TenderBotStore — Документация' \
+            '' \
+            'Добро пожаловать! Здесь описаны основы платформы и сервисов.' \
+            '' \
+            '## Быстрые ссылки' \
+            '' \
+            '- Архитектура → [ER‑схема](architecture/er-schema)' \
+            '- Архитектура → [Многотенантность и контекст](architecture/multitenancy)' \
+            '- Backend → [Гайд по миграциям (Liquibase)](backend/migrations)' \
+            '- Frontend → [Контекст на фронте](frontend/context)' \
+            '' \
+            '### Сервисы (стабильные)' \
+            '' \
+            '- [Auth](services/auth)' \
+            '- [Context](services/context)' \
+            '- [RBAC](services/rbac)' \
+            '- [Public Menu](services/menu)' \
+            '- [Health](services/health)' \
+            '- [Ошибки и коды](services/errors)' \
+            > wiki/Home.md
+          # Ensure sidebar exists (links without .md extensions)
           if [ ! -f wiki/_Sidebar.md ]; then
             printf '%s\n' \
               '* [Home](Home)' \
-              '* [Архитектура](architecture/er-schema.md)' \
-              '* [Многотенантность и контекст](architecture/multitenancy.md)' \
-              '* [RBAC](services/rbac.md)' \
-              '* [Миграции (Liquibase)](backend/migrations.md)' \
+              '* [Архитектура](architecture/er-schema)' \
+              '* [Многотенантность и контекст](architecture/multitenancy)' \
+              '* [RBAC](services/rbac)' \
+              '* [Миграции (Liquibase)](backend/migrations)' \
               > wiki/_Sidebar.md
           fi
 

--- a/README.md
+++ b/README.md
@@ -20,6 +20,21 @@ Master/Brand/Location и ролям Membership (RBAC). Репозиторий с
 - RBAC (BL‑2): [docs/services/rbac.md](docs/services/rbac.md)
 - Многотенантность/контекст: [docs/architecture/multitenancy.md](docs/architecture/multitenancy.md)
 
+#### Документация в Wiki (онлайн)
+
+- Главная Wiki: https://github.com/Kirillkgr/TenderBotStoreIdentityService/wiki/Home
+- Все внутренние ссылки в Wiki ведут на отрендеренные страницы (без расширения .md).
+
+### Документация API (Swagger/OpenAPI)
+
+- После запуска приложения откройте Swagger UI:
+    - http://localhost:8081/swagger-ui.html (или http://localhost:8081/swagger-ui)
+- Если UI недоступен — проверьте зависимость SpringDoc в `pom.xml`:
+    - `org.springdoc:springdoc-openapi-starter-webmvc-ui` (для Spring MVC)
+- Аннотации `@Operation` добавлены в контроллеры каталога, контекста, аутентификации, корзины, медиа, заказов и пр.,
+  включая пометки по ролям (RBAC).
+- Актуальную структуру и ссылки также смотрите в Wiki (см. выше).
+
 ## Технологический стек
 
 - **Java 21**: Основной язык программирования.

--- a/src/main/java/kirillzhdanov/identityservice/controller/AccountLinkController.java
+++ b/src/main/java/kirillzhdanov/identityservice/controller/AccountLinkController.java
@@ -1,5 +1,6 @@
 package kirillzhdanov.identityservice.controller;
 
+import io.swagger.v3.oas.annotations.Operation;
 import kirillzhdanov.identityservice.model.User;
 import kirillzhdanov.identityservice.model.UserProvider;
 import kirillzhdanov.identityservice.repository.UserRepository;
@@ -25,6 +26,7 @@ public class AccountLinkController {
     }
 
     @DeleteMapping("/google")
+    @Operation(summary = "Отвязать Google-аккаунт", description = "Требуется аутентификация. Удаляет привязку провайдера GOOGLE у текущего пользователя.")
     public ResponseEntity<Void> unlinkGoogle() {
         Authentication auth = SecurityContextHolder.getContext().getAuthentication();
         if (auth == null || !(auth.getPrincipal() instanceof CustomUserDetails cud)) {

--- a/src/main/java/kirillzhdanov/identityservice/controller/BotController.java
+++ b/src/main/java/kirillzhdanov/identityservice/controller/BotController.java
@@ -23,13 +23,13 @@ public class BotController {
 
 	/**
 	 * Регистрация нового Telegram-бота.
-	 *
 	 * @param request данные для регистрации бота
 	 * @return {@code 200 OK} – бот успешно зарегистрирован;
 	 * {@code 400 Bad Request} – некорректные данные;
 	 * {@code 409 Conflict} – бот с таким токеном уже существует.
 	 */
 	@PostMapping("/register")
+	@io.swagger.v3.oas.annotations.Operation(summary = "Регистрация Telegram-бота", description = "Требуется аутентификация и соответствующие права администратора платформы (если политика включена).")
 	public ResponseEntity<MessageResponse> registerBot(@Valid @RequestBody BotRegistrationRequest request) {
 
 		MessageResponse response = botService.registerBot(request);
@@ -45,6 +45,7 @@ public class BotController {
 	 * {@code 404 Not Found} – бот не найден.
 	 */
 	@PostMapping("/start")
+	@io.swagger.v3.oas.annotations.Operation(summary = "Запуск Telegram-бота", description = "Требуется аутентификация и соответствующие права администратора платформы (если политика включена).")
 	public ResponseEntity<MessageResponse> startBot(@Valid @RequestBody BotRegistrationRequest request) {
 
 		MessageResponse response = botService.startBot(request);

--- a/src/main/java/kirillzhdanov/identityservice/controller/BrandController.java
+++ b/src/main/java/kirillzhdanov/identityservice/controller/BrandController.java
@@ -1,5 +1,6 @@
 package kirillzhdanov.identityservice.controller;
 
+import io.swagger.v3.oas.annotations.Operation;
 import kirillzhdanov.identityservice.dto.BrandDto;
 import kirillzhdanov.identityservice.security.RbacGuard;
 import kirillzhdanov.identityservice.service.BrandService;
@@ -29,6 +30,7 @@ public class BrandController {
      * @return {@code ResponseEntity} со списком брендов и HTTP статусом {@code 200 OK}
      */
     @GetMapping
+    @Operation(summary = "Мои бренды", description = "Требования: аутентификация. Возвращает бренды в пределах текущего master контекста.")
     public ResponseEntity<List<BrandDto>> getAllBrands() {
 
         return ResponseEntity.ok(brandService.getMyBrands());
@@ -43,6 +45,7 @@ public class BrandController {
      * {@code 404 Not Found} - бренд с указанным ID не найден.
      */
     @GetMapping("/{id}")
+    @Operation(summary = "Бренд по ID", description = "Требования: аутентификация. Доступ только к своим брендам (чужие → 404).")
     public ResponseEntity<BrandDto> getBrandById(@PathVariable Long id) {
 
         return ResponseEntity.ok(brandService.getBrandById(id));
@@ -55,6 +58,7 @@ public class BrandController {
      * @return {@code ResponseEntity} с созданным брендом и HTTP статусом {@code 201 Created}
      */
     @PostMapping
+    @Operation(summary = "Создать бренд", description = "Требования: AUTH (любой аутентифицированный пользователь). Роль: CLIENT+ (будет владельцем созданного бренда).")
     public ResponseEntity<BrandDto> createBrand(@RequestBody BrandDto brandDto) {
         // Любой аутентифицированный пользователь может создать свой бренд (вариант Б)
         rbacGuard.requireAuthenticated();
@@ -70,6 +74,7 @@ public class BrandController {
      * {@code 404 Not Found} - бренд с указанным ID не найден.
      */
     @PutMapping("/{id}")
+    @Operation(summary = "Обновить бренд", description = "Требования: роль OWNER или ADMIN активного membership. Чужой бренд → 404; недостаточно прав → 403.")
     public ResponseEntity<BrandDto> updateBrand(@PathVariable Long id, @RequestBody BrandDto brandDto) {
         rbacGuard.requireOwnerOrAdmin();
         return ResponseEntity.ok(brandService.updateBrand(id, brandDto));
@@ -83,6 +88,7 @@ public class BrandController {
      * {@code 404 Not Found} - бренд с указанным ID не найден.
      */
     @DeleteMapping("/{id}")
+    @Operation(summary = "Удалить бренд", description = "Требования: роль OWNER или ADMIN активного membership. Чужой бренд → 404; недостаточно прав → 403.")
     public ResponseEntity<Void> deleteBrand(@PathVariable Long id) {
         rbacGuard.requireOwnerOrAdmin();
         brandService.deleteBrand(id);
@@ -99,6 +105,7 @@ public class BrandController {
      * {@code 404 Not Found} - пользователь или бренд не найдены.
      */
     @PostMapping("/{brandId}/users/{userId}")
+    @Operation(summary = "Назначить пользователя бренду", description = "Требования: роль OWNER или ADMIN активного membership.")
     public ResponseEntity<Void> assignUserToBrand(@PathVariable Long userId, @PathVariable Long brandId) {
         rbacGuard.requireOwnerOrAdmin();
         brandService.assignUserToBrand(userId, brandId);
@@ -116,6 +123,7 @@ public class BrandController {
      * {@code 400 Bad Request} - пользователь не назначен на бренд.
      */
     @DeleteMapping("/{brandId}/users/{userId}")
+    @Operation(summary = "Удалить пользователя из бренда", description = "Требования: роль OWNER или ADMIN активного membership.")
     public ResponseEntity<Void> removeUserFromBrand(@PathVariable Long userId, @PathVariable Long brandId) {
         rbacGuard.requireOwnerOrAdmin();
         brandService.removeUserFromBrand(userId, brandId);

--- a/src/main/java/kirillzhdanov/identityservice/controller/CartController.java
+++ b/src/main/java/kirillzhdanov/identityservice/controller/CartController.java
@@ -1,5 +1,6 @@
 package kirillzhdanov.identityservice.controller;
 
+import io.swagger.v3.oas.annotations.Operation;
 import jakarta.servlet.http.Cookie;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
@@ -43,6 +44,7 @@ public class CartController {
 
     @GetMapping
     @Transactional(readOnly = true)
+    @Operation(summary = "Текущая корзина", description = "Публично (гость/пользователь). Возвращает корзину по userId или по cart_token (cookie).")
     public ResponseEntity<?> getCart(HttpServletRequest request, HttpServletResponse response) {
         try {
             Optional<User> userOpt = getCurrentUser();
@@ -70,12 +72,13 @@ public class CartController {
 
     @PostMapping("/add")
     @Transactional
+    @Operation(summary = "Добавить в корзину", description = "Публично (гость/пользователь). Создаёт/использует cart_token для гостя. Возвращает обновлённую корзину или 409 при конфликте бренда.")
     public ResponseEntity<?> addToCart(@RequestBody Map<String, Object> payload,
                                        HttpServletRequest request,
                                        HttpServletResponse response) {
         try {
             Long productId = payload.get("productId") == null ? null : Long.valueOf(String.valueOf(payload.get("productId")));
-            Integer quantity = payload.get("quantity") == null ? 1 : Integer.parseInt(String.valueOf(payload.get("quantity")));
+            int quantity = payload.get("quantity") == null ? 1 : Integer.parseInt(String.valueOf(payload.get("quantity")));
             if (productId == null || quantity <= 0) {
                 return ResponseEntity.badRequest().body(Map.of("message", "productId и quantity обязательны"));
             }
@@ -160,6 +163,7 @@ public class CartController {
 
     @DeleteMapping("/remove/{id}")
     @Transactional
+    @Operation(summary = "Удалить позицию из корзины", description = "Публично (гость/пользователь). Разрешено владельцу userId или владельцу cart_token.")
     public ResponseEntity<?> removeFromCart(@PathVariable("id") Long cartItemId,
                                             HttpServletRequest request,
                                             HttpServletResponse response) {
@@ -186,6 +190,7 @@ public class CartController {
 
     @PatchMapping("/item/{id}")
     @Transactional
+    @Operation(summary = "Изменить количество позиции", description = "Публично (гость/пользователь). Разрешено владельцу userId или владельцу cart_token. qty<=0 удаляет позицию.")
     public ResponseEntity<?> updateQuantity(@PathVariable("id") Long cartItemId,
                                             @RequestBody Map<String, Object> payload,
                                             HttpServletRequest request,
@@ -224,6 +229,7 @@ public class CartController {
     }
 
     @DeleteMapping("/clear")
+    @Operation(summary = "Очистить корзину", description = "Публично (гость/пользователь). Очищает корзину пользователя или гостевую по cart_token.")
     public ResponseEntity<?> clearCart(HttpServletRequest request, HttpServletResponse response) {
         Optional<User> userOpt = getCurrentUser();
         String cartToken = getOrCreateCartToken(request, response);

--- a/src/main/java/kirillzhdanov/identityservice/controller/ContextController.java
+++ b/src/main/java/kirillzhdanov/identityservice/controller/ContextController.java
@@ -1,5 +1,6 @@
 package kirillzhdanov.identityservice.controller;
 
+import io.swagger.v3.oas.annotations.Operation;
 import kirillzhdanov.identityservice.dto.ContextSwitchRequest;
 import kirillzhdanov.identityservice.dto.ContextSwitchResponse;
 import kirillzhdanov.identityservice.exception.BadRequestException;
@@ -33,6 +34,7 @@ public class ContextController {
     private final TokenService tokenService;
 
     @PostMapping("/switch")
+    @Operation(summary = "Переключение контекста (membership)", description = "Требования: аутентификация. Меняет активный контекст и выдаёт новый accessToken. Ошибки: 400 при несоответствии membership/brand/location, 401 без аутентификации.")
     public ResponseEntity<ContextSwitchResponse> switchContext(@RequestBody ContextSwitchRequest request) {
         if (request.getMembershipId() == null) {
             throw new BadRequestException("membershipId is required");

--- a/src/main/java/kirillzhdanov/identityservice/controller/GroupTagController.java
+++ b/src/main/java/kirillzhdanov/identityservice/controller/GroupTagController.java
@@ -1,5 +1,6 @@
 package kirillzhdanov.identityservice.controller;
 
+import io.swagger.v3.oas.annotations.Operation;
 import jakarta.validation.Valid;
 import kirillzhdanov.identityservice.dto.group.*;
 import kirillzhdanov.identityservice.security.RbacGuard;
@@ -24,6 +25,7 @@ public class GroupTagController {
     private final RbacGuard rbacGuard;
 
     @PostMapping
+    @Operation(summary = "Создать группу тегов", description = "Требования: роль OWNER или ADMIN активного membership.")
     public ResponseEntity<GroupTagResponse> createGroupTag(
             @Valid @RequestBody CreateGroupTagRequest request) {
         rbacGuard.requireOwnerOrAdmin();
@@ -32,6 +34,7 @@ public class GroupTagController {
     }
 
     @GetMapping("/by-brand/{brandId}")
+    @Operation(summary = "Группы тегов по бренду/родителю", description = "Требования: аутентификация. Возвращает только доступные в текущем контексте.")
     public ResponseEntity<List<GroupTagResponse>> getGroupTagsByBrandAndParent(
             @PathVariable Long brandId,
             @RequestParam(required = false) Long parentId) {
@@ -41,17 +44,20 @@ public class GroupTagController {
     }
 
     @GetMapping("/tree/{brandId}")
+    @Operation(summary = "Дерево групп тегов", description = "Требования: аутентификация. Данные в пределах контекста.")
     public ResponseEntity<List<GroupTagResponse>> getGroupTagsTree(@PathVariable Long brandId) {
         List<GroupTagResponse> response = groupTagService.getGroupTagsTree(brandId);
         return ResponseEntity.ok(response);
     }
 
     @GetMapping("/tree/{brandId}/full")
+    @Operation(summary = "Полное дерево групп тегов", description = "Требования: аутентификация. Данные в пределах контекста.")
     public ResponseEntity<List<GroupTagTreeResponse>> tree(@PathVariable Long brandId) {
         return ResponseEntity.ok(groupTagService.tree(brandId));
     }
 
     @GetMapping("/by-brand/{brandId}/paged")
+    @Operation(summary = "Группы тегов (пагинация)", description = "Требования: аутентификация. Данные в пределах контекста.")
     public ResponseEntity<Page<GroupTagResponse>> getGroupTagsPaged(
             @PathVariable Long brandId,
             @RequestParam(required = false) Long parentId,
@@ -67,6 +73,7 @@ public class GroupTagController {
     }
 
     @PutMapping("/{groupTagId}")
+    @Operation(summary = "Переименовать группу", description = "Требования: роль OWNER или ADMIN активного membership.")
     public ResponseEntity<GroupTagResponse> rename(
             @PathVariable Long groupTagId,
             @RequestParam String name
@@ -77,6 +84,7 @@ public class GroupTagController {
 
     // Единый апдейт: смена бренда, перенос, переименование — одним запросом
     @PutMapping("/{groupTagId}/full")
+    @Operation(summary = "Полный апдейт группы", description = "Требования: роль OWNER или ADMIN активного membership.")
     public ResponseEntity<GroupTagResponse> updateFull(
             @PathVariable Long groupTagId,
             @Valid @RequestBody UpdateGroupTagRequest request
@@ -86,6 +94,7 @@ public class GroupTagController {
     }
 
     @PatchMapping("/{groupTagId}/move")
+    @Operation(summary = "Переместить группу", description = "Требования: роль OWNER или ADMIN активного membership.")
     public ResponseEntity<GroupTagResponse> move(
             @PathVariable Long groupTagId,
             @RequestParam(required = false) Long parentId
@@ -95,6 +104,7 @@ public class GroupTagController {
     }
 
     @PatchMapping("/{groupTagId}/brand")
+    @Operation(summary = "Сменить бренд у группы", description = "Требования: роль OWNER или ADMIN активного membership.")
     public ResponseEntity<GroupTagResponse> changeBrand(
             @PathVariable Long groupTagId,
             @RequestParam Long brandId
@@ -104,11 +114,13 @@ public class GroupTagController {
     }
 
     @GetMapping("/breadcrumbs/{groupTagId}")
+    @Operation(summary = "Хлебные крошки", description = "Требования: аутентификация. Данные в пределах контекста.")
     public ResponseEntity<List<GroupTagResponse>> breadcrumbs(@PathVariable Long groupTagId) {
         return ResponseEntity.ok(groupTagService.breadcrumbs(groupTagId));
     }
 
     @DeleteMapping("/{groupTagId}")
+    @Operation(summary = "Удалить группу (в архив)", description = "Требования: роль OWNER или ADMIN активного membership.")
     public ResponseEntity<Void> deleteWithArchive(@PathVariable Long groupTagId) {
         rbacGuard.requireOwnerOrAdmin();
         groupTagService.deleteWithArchive(groupTagId);
@@ -116,6 +128,7 @@ public class GroupTagController {
     }
 
     @DeleteMapping("/archive/purge")
+    @Operation(summary = "Очистить архив групп", description = "Требования: роль OWNER или ADMIN активного membership.")
     public ResponseEntity<Long> purgeArchive(@RequestParam(defaultValue = "90") int olderThanDays) {
         rbacGuard.requireOwnerOrAdmin();
         long deleted = groupTagService.purgeArchive(olderThanDays);
@@ -123,11 +136,13 @@ public class GroupTagController {
     }
 
     @GetMapping("/archive")
+    @Operation(summary = "Архив групп бренда", description = "Требования: аутентификация. Данные в пределах контекста.")
     public ResponseEntity<java.util.List<GroupTagArchiveResponse>> listArchiveByBrand(@RequestParam Long brandId) {
         return ResponseEntity.ok(groupTagService.listArchiveByBrand(brandId));
     }
 
     @GetMapping("/archive/paged")
+    @Operation(summary = "Архив групп бренда (пагинация)", description = "Требования: аутентификация. Данные в пределах контекста.")
     public ResponseEntity<Page<GroupTagArchiveResponse>> listArchiveByBrandPaged(
             @RequestParam Long brandId,
             @RequestParam(defaultValue = "0") int page,
@@ -141,6 +156,7 @@ public class GroupTagController {
     }
 
     @PostMapping("/archive/{archiveId}/restore")
+    @Operation(summary = "Восстановить группу из архива", description = "Требования: роль OWNER или ADMIN активного membership.")
     public ResponseEntity<GroupTagResponse> restoreFromArchive(
             @PathVariable Long archiveId,
             @RequestParam(required = false) Long targetParentId
@@ -150,6 +166,7 @@ public class GroupTagController {
     }
 
     @DeleteMapping("/archive/{archiveId}")
+    @Operation(summary = "Удалить запись архива группы", description = "Требования: роль OWNER или ADMIN активного membership.")
     public ResponseEntity<Void> deleteGroupArchive(@PathVariable Long archiveId) {
         rbacGuard.requireOwnerOrAdmin();
         groupTagService.deleteGroupArchive(archiveId);

--- a/src/main/java/kirillzhdanov/identityservice/controller/MediaController.java
+++ b/src/main/java/kirillzhdanov/identityservice/controller/MediaController.java
@@ -1,5 +1,6 @@
 package kirillzhdanov.identityservice.controller;
 
+import io.swagger.v3.oas.annotations.Operation;
 import kirillzhdanov.identityservice.dto.ProductImageRef;
 import kirillzhdanov.identityservice.dto.TagImageRef;
 import kirillzhdanov.identityservice.service.ImageProcessingService;
@@ -26,6 +27,8 @@ public class MediaController {
     private final MediaService mediaService;
 
     @PostMapping("/upload")
+    @Operation(summary = "Загрузка изображения товара",
+            description = "Требуется аутентификация. Рекомендуется роль OWNER/ADMIN для управления медиа каталога.")
     public ResponseEntity<?> upload(
             @RequestParam("file") MultipartFile file,
             @RequestParam("productId") String productId,
@@ -70,6 +73,8 @@ public class MediaController {
     // New endpoints for overwrite/delete/regenerate and tag groups
 
     @PostMapping("/product/overwrite")
+    @Operation(summary = "Перезагрузка изображения товара",
+            description = "Требуется аутентификация. Рекомендуется роль OWNER/ADMIN.")
     public ResponseEntity<?> overwriteProduct(
             @RequestParam("file") MultipartFile file,
             @RequestParam("productId") String productId,
@@ -88,12 +93,16 @@ public class MediaController {
     }
 
     @DeleteMapping("/product/derived")
+    @Operation(summary = "Удаление производных изображений товара",
+            description = "Требуется аутентификация. Рекомендуется роль OWNER/ADMIN.")
     public ResponseEntity<Void> deleteProductDerived(@RequestParam String productId, @RequestParam String imageId) {
         mediaService.deleteDerivedProduct(productId, imageId);
         return ResponseEntity.ok().build();
     }
 
     @PostMapping("/product/regenerate")
+    @Operation(summary = "Регенерация производных изображений товара",
+            description = "Требуется аутентификация. Рекомендуется роль OWNER/ADMIN.")
     public ResponseEntity<?> regenerateProduct(@RequestParam String productId,
                                                @RequestParam String imageId,
                                                @RequestParam(value = "publicForHomepage", defaultValue = "false") boolean publicForHomepage) throws IOException {
@@ -108,6 +117,8 @@ public class MediaController {
     }
 
     @DeleteMapping("/product/hard")
+    @Operation(summary = "Полное удаление изображения товара",
+            description = "Требуется аутентификация. Рекомендуется роль OWNER/ADMIN.")
     public ResponseEntity<Void> hardDeleteProduct(@RequestParam String productId, @RequestParam String imageId) {
         mediaService.hardDeleteProduct(productId, imageId);
         return ResponseEntity.ok().build();
@@ -115,6 +126,8 @@ public class MediaController {
 
     // Tag group variants
     @PostMapping("/tag/upload")
+    @Operation(summary = "Загрузка изображения группы тегов",
+            description = "Требуется аутентификация. Рекомендуется роль OWNER/ADMIN.")
     public ResponseEntity<?> uploadTag(
             @RequestParam("file") MultipartFile file,
             @RequestParam("tagGroupId") String tagGroupId,
@@ -131,6 +144,8 @@ public class MediaController {
     }
 
     @PostMapping("/tag/overwrite")
+    @Operation(summary = "Перезагрузка изображения группы тегов",
+            description = "Требуется аутентификация. Рекомендуется роль OWNER/ADMIN.")
     public ResponseEntity<?> overwriteTag(
             @RequestParam("file") MultipartFile file,
             @RequestParam("tagGroupId") String tagGroupId,
@@ -148,12 +163,16 @@ public class MediaController {
     }
 
     @DeleteMapping("/tag/derived")
+    @Operation(summary = "Удаление производных изображений группы тегов",
+            description = "Требуется аутентификация. Рекомендуется роль OWNER/ADMIN.")
     public ResponseEntity<Void> deleteTagDerived(@RequestParam String tagGroupId, @RequestParam String imageId) {
         mediaService.deleteDerivedTagGroup(tagGroupId, imageId);
         return ResponseEntity.ok().build();
     }
 
     @PostMapping("/tag/regenerate")
+    @Operation(summary = "Регенерация производных изображений группы тегов",
+            description = "Требуется аутентификация. Рекомендуется роль OWNER/ADMIN.")
     public ResponseEntity<?> regenerateTag(@RequestParam String tagGroupId,
                                            @RequestParam String imageId,
                                            @RequestParam(value = "publicForHomepage", defaultValue = "false") boolean publicForHomepage) throws IOException {
@@ -168,6 +187,8 @@ public class MediaController {
     }
 
     @DeleteMapping("/tag/hard")
+    @Operation(summary = "Полное удаление изображения группы тегов",
+            description = "Требуется аутентификация. Рекомендуется роль OWNER/ADMIN.")
     public ResponseEntity<Void> hardDeleteTag(@RequestParam String tagGroupId, @RequestParam String imageId) {
         mediaService.hardDeleteTagGroup(tagGroupId, imageId);
         return ResponseEntity.ok().build();
@@ -176,6 +197,8 @@ public class MediaController {
     // ==================== BATCH endpoints ====================
 
     @PostMapping("/product/derived-batch")
+    @Operation(summary = "Batch: удалить производные изображения товара",
+            description = "Требуется аутентификация. Рекомендуется роль OWNER/ADMIN.")
     public ResponseEntity<Map<String, Object>> deleteProductDerivedBatch(@RequestBody List<ProductImageRef> refs) {
         int count = 0;
         for (ProductImageRef ref : refs) {
@@ -186,6 +209,8 @@ public class MediaController {
     }
 
     @PostMapping("/product/regenerate-batch")
+    @Operation(summary = "Batch: регенерация производных изображений товара",
+            description = "Требуется аутентификация. Рекомендуется роль OWNER/ADMIN.")
     public ResponseEntity<Map<String, Object>> regenerateProductBatch(@RequestBody List<ProductImageRef> refs,
                                                                       @RequestParam(value = "publicForHomepage", defaultValue = "false") boolean publicForHomepage) throws java.io.IOException {
         List<Map<String, Object>> results = new ArrayList<>();
@@ -203,6 +228,8 @@ public class MediaController {
     }
 
     @PostMapping("/product/hard-batch")
+    @Operation(summary = "Batch: полное удаление изображений товара",
+            description = "Требуется аутентификация. Рекомендуется роль OWNER/ADMIN.")
     public ResponseEntity<Map<String, Object>> hardDeleteProductBatch(@RequestBody List<ProductImageRef> refs) {
         int count = 0;
         for (ProductImageRef ref : refs) {
@@ -213,6 +240,8 @@ public class MediaController {
     }
 
     @PostMapping("/tag/derived-batch")
+    @Operation(summary = "Batch: удалить производные изображения группы тегов",
+            description = "Требуется аутентификация. Рекомендуется роль OWNER/ADMIN.")
     public ResponseEntity<Map<String, Object>> deleteTagDerivedBatch(@RequestBody List<TagImageRef> refs) {
         int count = 0;
         for (TagImageRef ref : refs) {
@@ -223,6 +252,8 @@ public class MediaController {
     }
 
     @PostMapping("/tag/regenerate-batch")
+    @Operation(summary = "Batch: регенерация производных изображений группы тегов",
+            description = "Требуется аутентификация. Рекомендуется роль OWNER/ADMIN.")
     public ResponseEntity<Map<String, Object>> regenerateTagBatch(@RequestBody List<TagImageRef> refs,
                                                                   @RequestParam(value = "publicForHomepage", defaultValue = "false") boolean publicForHomepage) throws java.io.IOException {
         List<Map<String, Object>> results = new ArrayList<>();
@@ -240,6 +271,8 @@ public class MediaController {
     }
 
     @PostMapping("/tag/hard-batch")
+    @Operation(summary = "Batch: полное удаление изображений группы тегов",
+            description = "Требуется аутентификация. Рекомендуется роль OWNER/ADMIN.")
     public ResponseEntity<Map<String, Object>> hardDeleteTagBatch(@RequestBody List<TagImageRef> refs) {
         int count = 0;
         for (TagImageRef ref : refs) {

--- a/src/main/java/kirillzhdanov/identityservice/controller/MenuController.java
+++ b/src/main/java/kirillzhdanov/identityservice/controller/MenuController.java
@@ -1,5 +1,6 @@
 package kirillzhdanov.identityservice.controller;
 
+import io.swagger.v3.oas.annotations.Operation;
 import kirillzhdanov.identityservice.dto.BrandDto;
 import kirillzhdanov.identityservice.dto.group.GroupTagResponse;
 import kirillzhdanov.identityservice.dto.menu.PublicBrandResponse;
@@ -27,6 +28,7 @@ public class MenuController {
 
     // 1) Публичный список брендов (минимум данных)
     @GetMapping("/brands")
+    @Operation(summary = "Публичные бренды", description = "Публично. Возвращает список брендов (минимальная информация).")
     public ResponseEntity<List<PublicBrandResponse>> getBrands() {
         List<BrandDto> brands = brandService.getAllBrandsPublic();
         List<PublicBrandResponse> response = brands.stream()
@@ -37,6 +39,7 @@ public class MenuController {
 
     // 2) Публичная карточка бренда (минимум данных)
     @GetMapping("/brands/{brandId}")
+    @Operation(summary = "Публичная карточка бренда", description = "Публично. Минимальные поля.")
     public ResponseEntity<PublicBrandResponse> getBrand(@PathVariable Long brandId) {
         BrandDto b = brandService.getBrandById(brandId);
         return ResponseEntity.ok(new PublicBrandResponse(b.getId(), b.getName()));
@@ -44,6 +47,7 @@ public class MenuController {
 
     // 3) Публичные теги бренда по родителю (parentId=0 -> корневые)
     @GetMapping("/brands/{brandId}/tags")
+    @Operation(summary = "Публичные теги бренда", description = "Публично. Скрывает пустые группы.")
     public ResponseEntity<List<PublicGroupTagResponse>> getBrandTags(
             @PathVariable Long brandId,
             @RequestParam(required = false, defaultValue = "0") Long parentId
@@ -59,6 +63,7 @@ public class MenuController {
 
     // 4) Публичные товары бренда по группе (groupTagId=0 -> корневые). Всегда только видимые.
     @GetMapping("/brands/{brandId}/products")
+    @Operation(summary = "Публичные товары бренда", description = "Публично. Всегда только видимые товары.")
     public ResponseEntity<List<PublicProductResponse>> getBrandProducts(
             @PathVariable Long brandId,
             @RequestParam(required = false, defaultValue = "0") Long groupTagId
@@ -72,6 +77,7 @@ public class MenuController {
 
     // ALIAS: совместимость с путём вида /menu/v1/products/by-brand/{brandId}
     @GetMapping("/products/by-brand/{brandId}")
+    @Operation(summary = "Alias: публичные товары бренда", description = "Публично. Алиас на /brands/{brandId}/products.")
     public ResponseEntity<List<PublicProductResponse>> getBrandProductsAlias(
             @PathVariable Long brandId,
             @RequestParam(required = false, defaultValue = "0") Long groupTagId
@@ -81,6 +87,7 @@ public class MenuController {
 
     // ALIAS: совместимость с путём вида /menu/v1/tags/by-brand/{brandId}
     @GetMapping("/tags/by-brand/{brandId}")
+    @Operation(summary = "Alias: публичные теги бренда", description = "Публично. Алиас на /brands/{brandId}/tags.")
     public ResponseEntity<List<PublicGroupTagResponse>> getBrandTagsAlias(
             @PathVariable Long brandId,
             @RequestParam(required = false, defaultValue = "0") Long parentId
@@ -90,6 +97,7 @@ public class MenuController {
 
     // ALIAS: совместимость с путём вида /menu/v1/group-tags/by-brand/{brandId}
     @GetMapping("/group-tags/by-brand/{brandId}")
+    @Operation(summary = "Alias: публичные группы тегов бренда", description = "Публично. Алиас на /brands/{brandId}/tags.")
     public ResponseEntity<List<PublicGroupTagResponse>> getBrandGroupTagsAlias(
             @PathVariable Long brandId,
             @RequestParam(required = false, defaultValue = "0") Long parentId

--- a/src/main/java/kirillzhdanov/identityservice/controller/ProductController.java
+++ b/src/main/java/kirillzhdanov/identityservice/controller/ProductController.java
@@ -1,5 +1,6 @@
 package kirillzhdanov.identityservice.controller;
 
+import io.swagger.v3.oas.annotations.Operation;
 import jakarta.validation.Valid;
 import jakarta.validation.constraints.NotNull;
 import kirillzhdanov.identityservice.dto.product.ProductArchiveResponse;
@@ -29,6 +30,7 @@ public class ProductController {
      * Создание товара в корне бренда или внутри выбранного тега
      */
     @PostMapping
+    @Operation(summary = "Создать товар", description = "Требования: роль OWNER или ADMIN активного membership. Чужой бренд → 404; недостаточно прав → 403.")
     public ResponseEntity<ProductResponse> create(@Valid @RequestBody ProductCreateRequest request) {
         rbacGuard.requireOwnerOrAdmin();
         ProductResponse response = productService.create(request);
@@ -39,6 +41,7 @@ public class ProductController {
      * Получить карточку товара по id
      */
     @GetMapping("/{productId}")
+    @Operation(summary = "Товар по ID", description = "Требования: аутентификация; доступ только к товарам в пределах контекста (чужие → 404). Публичный аналог см. /menu/v1.")
     public ResponseEntity<ProductResponse> getById(@PathVariable Long productId) {
         return ResponseEntity.ok(productService.getById(productId));
     }
@@ -49,6 +52,7 @@ public class ProductController {
      * visibleOnly по умолчанию true – возвращать только видимые товары.
      */
     @GetMapping("/by-brand/{brandId}")
+    @Operation(summary = "Товары бренда (внутренний)", description = "Требования: аутентификация. Для публичного меню используйте /menu/v1/brands/{brandId}/products.")
     public ResponseEntity<List<ProductResponse>> getByBrandAndGroup(
             @PathVariable Long brandId,
             @RequestParam(required = false) Long groupTagId,
@@ -62,6 +66,7 @@ public class ProductController {
      * Обновление карточки товара
      */
     @PutMapping("/{productId}")
+    @Operation(summary = "Обновить товар", description = "Требования: роль OWNER или ADMIN активного membership.")
     public ResponseEntity<ProductResponse> update(
             @PathVariable Long productId,
             @Valid @RequestBody ProductUpdateRequest request
@@ -75,6 +80,7 @@ public class ProductController {
      * Обновление флага видимости товара
      */
     @PatchMapping("/{productId}/visibility")
+    @Operation(summary = "Сменить видимость товара", description = "Требования: роль OWNER или ADMIN активного membership.")
     public ResponseEntity<ProductResponse> updateVisibility(
             @PathVariable Long productId,
             @RequestParam @NotNull Boolean visible
@@ -88,6 +94,7 @@ public class ProductController {
      * Смена бренда у товара (при смене бренда группа сбрасывается, если относится к другому бренду)
      */
     @PatchMapping("/{productId}/brand")
+    @Operation(summary = "Сменить бренд товара", description = "Требования: роль OWNER или ADMIN активного membership.")
     public ResponseEntity<ProductResponse> changeBrand(
             @PathVariable Long productId,
             @RequestParam @NotNull Long brandId
@@ -101,6 +108,7 @@ public class ProductController {
      * Удаление товара в архив (мягкое удаление для пользователя). В будущем архив будет чиститься автоматически.
      */
     @DeleteMapping("/{productId}")
+    @Operation(summary = "Архивировать товар", description = "Требования: роль OWNER или ADMIN активного membership.")
     public ResponseEntity<Void> deleteToArchive(@PathVariable Long productId) {
         rbacGuard.requireOwnerOrAdmin();
         productService.deleteToArchive(productId);
@@ -111,6 +119,7 @@ public class ProductController {
      * Перемещение товара между группами (или в корень бренда при targetGroupTagId = 0)
      */
     @PatchMapping("/{productId}/move")
+    @Operation(summary = "Переместить товар", description = "Требования: роль OWNER или ADMIN активного membership.")
     public ResponseEntity<ProductResponse> move(
             @PathVariable Long productId,
             @RequestParam(required = false) Long targetGroupTagId
@@ -124,6 +133,7 @@ public class ProductController {
      * Список архива по бренду
      */
     @GetMapping("/archive")
+    @Operation(summary = "Архив товаров бренда", description = "Требования: аутентификация. Данные в пределах контекста.")
     public ResponseEntity<List<ProductArchiveResponse>> listArchiveByBrand(@RequestParam @NotNull Long brandId) {
         return ResponseEntity.ok(productService.listArchiveByBrand(brandId));
     }
@@ -132,6 +142,7 @@ public class ProductController {
      * Пагинированный список архива по бренду
      */
     @GetMapping("/archive/paged")
+    @Operation(summary = "Архив товаров бренда (пагинация)", description = "Требования: аутентификация. Данные в пределах контекста.")
     public ResponseEntity<Page<ProductArchiveResponse>> listArchiveByBrandPaged(
             @RequestParam @NotNull Long brandId,
             Pageable pageable
@@ -143,6 +154,7 @@ public class ProductController {
      * Восстановление из архива в исходную или указанную группу
      */
     @PostMapping("/archive/{archiveId}/restore")
+    @Operation(summary = "Восстановить товар из архива", description = "Требования: роль OWNER или ADMIN активного membership.")
     public ResponseEntity<ProductResponse> restoreFromArchive(
             @PathVariable Long archiveId,
             @RequestParam(required = false) Long targetGroupTagId
@@ -155,6 +167,7 @@ public class ProductController {
      * Удалить запись из архива
      */
     @DeleteMapping("/archive/{archiveId}")
+    @Operation(summary = "Удалить запись архива", description = "Требования: роль OWNER или ADMIN активного membership.")
     public ResponseEntity<Void> deleteArchive(@PathVariable Long archiveId) {
         rbacGuard.requireOwnerOrAdmin();
         productService.deleteArchive(archiveId);
@@ -165,6 +178,7 @@ public class ProductController {
      * Очистка архива старше N дней (по умолчанию 90)
      */
     @DeleteMapping("/archive/purge")
+    @Operation(summary = "Очистить архив", description = "Требования: роль OWNER или ADMIN активного membership.")
     public ResponseEntity<Long> purgeArchive(@RequestParam(defaultValue = "90") int olderThanDays) {
         rbacGuard.requireOwnerOrAdmin();
         long deleted = productService.purgeArchive(olderThanDays);

--- a/src/main/java/kirillzhdanov/identityservice/controller/StaffController.java
+++ b/src/main/java/kirillzhdanov/identityservice/controller/StaffController.java
@@ -1,5 +1,6 @@
 package kirillzhdanov.identityservice.controller;
 
+import io.swagger.v3.oas.annotations.Operation;
 import jakarta.validation.Valid;
 import kirillzhdanov.identityservice.dto.staff.*;
 import kirillzhdanov.identityservice.model.User;
@@ -21,6 +22,7 @@ public class StaffController {
 
     @PreAuthorize("hasAnyRole('ADMIN','OWNER')")
     @GetMapping("/users")
+    @Operation(summary = "Список пользователей (персонал)", description = "Требования: глобальная роль ROLE_ADMIN или ROLE_OWNER (PreAuthorize). Данные ограничены контекстом master, если не передан masterId.")
     public ResponseEntity<PagedResponse<UserListItemDto>> listUsers(
             @RequestParam(required = false) Long masterId,
             @RequestParam(required = false) String query,
@@ -38,12 +40,14 @@ public class StaffController {
 
     @PreAuthorize("hasAnyRole('ADMIN','OWNER')")
     @PostMapping("/users")
+    @Operation(summary = "Создать пользователя (персонал)", description = "Требования: глобальная роль ROLE_ADMIN или ROLE_OWNER (PreAuthorize).")
     public ResponseEntity<UserListItemDto> createUser(@Valid @RequestBody CreateUserRequest req) {
         return ResponseEntity.ok(staffService.createUser(req));
     }
 
     @PreAuthorize("hasAnyRole('ADMIN','OWNER')")
     @PutMapping("/users/{id}")
+    @Operation(summary = "Обновить пользователя (персонал)", description = "Требования: глобальная роль ROLE_ADMIN или ROLE_OWNER (PreAuthorize).")
     public ResponseEntity<UserListItemDto> updateUser(@PathVariable Long id, @Valid @RequestBody UpdateStaffUserRequest req,
                                                       Authentication auth) {
         Long masterId = (auth != null && auth.isAuthenticated())
@@ -54,6 +58,7 @@ public class StaffController {
 
     @PreAuthorize("hasAnyRole('ADMIN','OWNER')")
     @DeleteMapping("/users/{id}")
+    @Operation(summary = "Удалить пользователя (персонал)", description = "Требования: глобальная роль ROLE_ADMIN или ROLE_OWNER (PreAuthorize).")
     public ResponseEntity<Void> deleteUser(@PathVariable Long id, Authentication auth) {
         Long masterId = (auth != null && auth.isAuthenticated())
                 ? userRepository.findByUsername(auth.getName()).map(User::getId).orElse(null)
@@ -64,12 +69,14 @@ public class StaffController {
 
     @PreAuthorize("hasAnyRole('ADMIN','OWNER')")
     @PostMapping("/departments")
+    @Operation(summary = "Создать отдел", description = "Требования: глобальная роль ROLE_ADMIN или ROLE_OWNER (PreAuthorize).")
     public ResponseEntity<DepartmentDto> createDepartment(@Valid @RequestBody DepartmentCreateRequest req) {
         return ResponseEntity.ok(staffService.createDepartment(req));
     }
 
     @PreAuthorize("hasAnyRole('ADMIN','OWNER')")
     @GetMapping("/departments")
+    @Operation(summary = "Список отделов", description = "Требования: глобальная роль ROLE_ADMIN или ROLE_OWNER (PreAuthorize).")
     public ResponseEntity<java.util.List<DepartmentDto>> listDepartments() {
         return ResponseEntity.ok(staffService.listDepartments());
     }

--- a/src/main/java/kirillzhdanov/identityservice/controller/TokenValidationController.java
+++ b/src/main/java/kirillzhdanov/identityservice/controller/TokenValidationController.java
@@ -1,5 +1,6 @@
 package kirillzhdanov.identityservice.controller;
 
+import io.swagger.v3.oas.annotations.Operation;
 import kirillzhdanov.identityservice.dto.JwtUserDetailsResponse;
 import kirillzhdanov.identityservice.security.JwtUtils;
 import kirillzhdanov.identityservice.service.TokenService;
@@ -40,6 +41,7 @@ public class TokenValidationController {
 	 * {@code 403 Forbidden} - токен невалиден (некорректный заголовок, неверная подпись, отозванный токен).
 	 */
 	@PostMapping
+	@Operation(summary = "Валидация JWT", description = "Публично. Принимает Authorization: Bearer <token>. Возвращает 200 если токен валиден, 403 иначе.")
 	public ResponseEntity<Void> validateToken(@RequestHeader("Authorization") String authHeader) {
 
 		log.warn("Включить когда потребуется реальная валидация токена\n " + authHeader);
@@ -84,6 +86,7 @@ public class TokenValidationController {
 	 * {@code 403 Forbidden} - токен невалиден (некорректный заголовок, неверная подпись, отозванный токен) или пользователь не найден.
 	 */
 	@PostMapping("/details")
+	@Operation(summary = "Валидация JWT + данные пользователя", description = "Публично. Принимает Authorization: Bearer <token>. Возвращает 200 и информацию о пользователе, 403 при ошибке.")
 	public ResponseEntity<JwtUserDetailsResponse> validateTokenAndGetUserDetails(@RequestHeader("Authorization") String authHeader) {
 
 		if (authHeader == null || !authHeader.startsWith("Bearer ")) {

--- a/src/main/java/kirillzhdanov/identityservice/controller/order/OrderController.java
+++ b/src/main/java/kirillzhdanov/identityservice/controller/order/OrderController.java
@@ -1,5 +1,6 @@
 package kirillzhdanov.identityservice.controller.order;
 
+import io.swagger.v3.oas.annotations.Operation;
 import jakarta.validation.Valid;
 import kirillzhdanov.identityservice.dto.order.CourierMessageRequest;
 import kirillzhdanov.identityservice.dto.order.OrderDto;
@@ -48,6 +49,7 @@ public class OrderController {
 
     @GetMapping("/my")
     @Transactional(readOnly = true)
+    @Operation(summary = "Мои заказы", description = "Требуется аутентификация. Возвращает заказы текущего пользователя.")
     public ResponseEntity<?> myOrders(Authentication authentication) {
         if (!isAuthenticated(authentication)) return ResponseEntity.status(401).build();
         User user = resolveUser(authentication);
@@ -96,6 +98,7 @@ public class OrderController {
     }
 
     @GetMapping("/orders")
+    @Operation(summary = "Доступные заказы (по membership)", description = "Требуется аутентификация. Возвращает заказы по брендам, где у пользователя есть membership.")
     public ResponseEntity<Page<OrderDto>> getAccessibleOrders(Pageable pageable,
                                                               Authentication authentication,
                                                               @RequestParam(required = false) String search,
@@ -113,6 +116,7 @@ public class OrderController {
     }
 
     @GetMapping("/brand/{brandId}/orders")
+    @Operation(summary = "Заказы бренда", description = "Требуется аутентификация. Доступ только при наличии membership у бренда; иначе 403.")
     public ResponseEntity<Page<OrderDto>> getBrandOrders(@PathVariable Long brandId,
                                                          Pageable pageable,
                                                          Authentication authentication) {
@@ -127,6 +131,7 @@ public class OrderController {
     }
 
     @PatchMapping("/orders/{id}/status")
+    @Operation(summary = "Смена статуса заказа", description = "Требуется аутентификация и membership у бренда заказа. Рекомендовано ограничить ролями (CASHIER/COOK/ADMIN/OWNER).")
     public ResponseEntity<Void> updateStatus(@PathVariable Long id,
                                              @Valid @RequestBody UpdateOrderStatusRequest req,
                                              Authentication authentication) {
@@ -155,6 +160,7 @@ public class OrderController {
     }
 
     @PostMapping("/orders/{id}/message")
+    @Operation(summary = "Сообщение курьера/персонала клиенту", description = "Требуется аутентификация и membership у бренда заказа.")
     public ResponseEntity<Void> sendCourierMessage(@PathVariable Long id,
                                                    @Valid @RequestBody CourierMessageRequest req,
                                                    Authentication authentication) {
@@ -185,6 +191,7 @@ public class OrderController {
 
     // Клиент пишет администратору/персоналу бренда по заказу
     @PostMapping("/orders/{id}/client-message")
+    @Operation(summary = "Сообщение клиента персоналу", description = "Требуется аутентификация. Разрешено только клиенту данного заказа.")
     public ResponseEntity<Void> sendClientMessage(@PathVariable Long id,
                                                   @Valid @RequestBody CourierMessageRequest req, // reuse dto with 'text'
                                                   Authentication authentication) {
@@ -232,6 +239,7 @@ public class OrderController {
     }
 
     @PostMapping("/orders/{id}/review")
+    @Operation(summary = "Отправить отзыв по заказу", description = "Требуется аутентификация. Разрешено клиенту заказа после статуса COMPLETED. Повторная отправка запрещена.")
     public ResponseEntity<Void> submitReview(@PathVariable Long id,
                                              @Valid @RequestBody ReviewRequest req,
                                              Authentication authentication) {
@@ -266,6 +274,7 @@ public class OrderController {
     }
 
     @GetMapping("/orders/{id}/messages")
+    @Operation(summary = "Сообщения заказа", description = "Требуется аутентификация. Доступ клиенту заказа и сотрудникам бренда (membership).")
     public ResponseEntity<?> getOrderMessages(@PathVariable Long id,
                                               Authentication authentication) {
         if (!isAuthenticated(authentication)) return ResponseEntity.status(401).build();

--- a/src/main/java/kirillzhdanov/identityservice/controller/pickup/PickupPointController.java
+++ b/src/main/java/kirillzhdanov/identityservice/controller/pickup/PickupPointController.java
@@ -1,5 +1,6 @@
 package kirillzhdanov.identityservice.controller.pickup;
 
+import io.swagger.v3.oas.annotations.Operation;
 import kirillzhdanov.identityservice.model.pickup.PickupPoint;
 import kirillzhdanov.identityservice.repository.pickup.PickupPointRepository;
 import lombok.RequiredArgsConstructor;
@@ -21,6 +22,7 @@ public class PickupPointController {
     private final PickupPointRepository pickupPointRepository;
 
     @GetMapping
+    @Operation(summary = "Пункты самовывоза бренда (внутренний)", description = "Требуется аутентификация. Возвращает активные точки самовывоза бренда.")
     public ResponseEntity<List<PickupPoint>> getActivePickupPoints(@PathVariable Long brandId,
                                                                    Authentication authentication) {
         if (authentication == null || !authentication.isAuthenticated() || authentication instanceof AnonymousAuthenticationToken) {

--- a/src/main/java/kirillzhdanov/identityservice/controller/publicapi/PublicPickupPointController.java
+++ b/src/main/java/kirillzhdanov/identityservice/controller/publicapi/PublicPickupPointController.java
@@ -1,5 +1,6 @@
 package kirillzhdanov.identityservice.controller.publicapi;
 
+import io.swagger.v3.oas.annotations.Operation;
 import kirillzhdanov.identityservice.model.pickup.PickupPoint;
 import kirillzhdanov.identityservice.repository.pickup.PickupPointRepository;
 import kirillzhdanov.identityservice.util.BrandContextHolder;
@@ -19,6 +20,7 @@ public class PublicPickupPointController {
     private final PickupPointRepository pickupPointRepository;
 
     @GetMapping
+    @Operation(summary = "Публичные пункты самовывоза текущего бренда", description = "Публично. Определяет brandId из BrandContextHolder и возвращает активные точки.")
     public ResponseEntity<List<PickupPoint>> listActiveForCurrentBrand() {
         Long brandId = BrandContextHolder.get();
         if (brandId == null) {


### PR DESCRIPTION
- Описание PR:
    - Добавлены `@Operation` (OpenAPI) с краткими пометками о ролях и аутентификации в ключевых контроллерах:
        - [BrandController](cci:2://file:///C:/Users/RillG/IdeaProjects/TenderBotStoreIdentityService/src/main/java/kirillzhdanov/identityservice/controller/BrandController.java:18:0-132:1), [ProductController](cci:2://file:///C:/Users/RillG/IdeaProjects/TenderBotStoreIdentityService/src/main/java/kirillzhdanov/identityservice/controller/ProductController.java:20:0-186:1), [GroupTagController](cci:2://file:///C:/Users/RillG/IdeaProjects/TenderBotStoreIdentityService/src/main/java/kirillzhdanov/identityservice/controller/GroupTagController.java:18:0-174:1)
        - [ContextController](cci:2://file:///C:/Users/RillG/IdeaProjects/TenderBotStoreIdentityService/src/main/java/kirillzhdanov/identityservice/controller/ContextController.java:25:0-71:1), [AuthController](cci:2://file:///C:/Users/RillG/IdeaProjects/TenderBotStoreIdentityService/src/main/java/kirillzhdanov/identityservice/controller/AuthController.java:26:0-223:1), [StaffController](cci:2://file:///C:/Users/RillG/IdeaProjects/TenderBotStoreIdentityService/src/main/java/kirillzhdanov/identityservice/controller/StaffController.java:14:0-82:1)
        - [MenuController](cci:2://file:///C:/Users/RillG/IdeaProjects/TenderBotStoreIdentityService/src/main/java/kirillzhdanov/identityservice/controller/MenuController.java:19:0-106:1) (публичные), `checkout/CheckoutController`
        - `order/OrderController`, [MediaController](cci:2://file:///C:/Users/RillG/IdeaProjects/TenderBotStoreIdentityService/src/main/java/kirillzhdanov/identityservice/controller/MediaController.java:19:0-283:1), [CartController](cci:2://file:///C:/Users/RillG/IdeaProjects/TenderBotStoreIdentityService/src/main/java/kirillzhdanov/identityservice/controller/CartController.java:27:0-308:1)
        - [AccountLinkController](cci:2://file:///C:/Users/RillG/IdeaProjects/TenderBotStoreIdentityService/src/main/java/kirillzhdanov/identityservice/controller/AccountLinkController.java:15:0-41:1), [TokenValidationController](cci:2://file:///C:/Users/RillG/IdeaProjects/TenderBotStoreIdentityService/src/main/java/kirillzhdanov/identityservice/controller/TokenValidationController.java:20:0-134:1)
        - `pickup/PickupPointController` (внутр.), `publicapi/PublicPickupPointController` (публичн.)
    - В [README.md](cci:7://file:///C:/Users/RillG/IdeaProjects/TenderBotStoreIdentityService/README.md:0:0-0:0):
        - Добавлен раздел “Документация API (Swagger/OpenAPI)” — как открыть UI, требуемая зависимость SpringDoc.
        - Добавлен раздел “Документация в Wiki (онлайн)” — прямая ссылка на Home и пояснение про отрендеренные ссылки.
    - В workflow [docs-wiki-pr.yml](cci:7://file:///C:/Users/RillG/IdeaProjects/TenderBotStoreIdentityService/.github/workflows/docs-wiki-pr.yml:0:0-0:0) (Docs → GitHub Wiki):
        - Генерация `Home.md` для Wiki с “чистыми” ссылками без [.md](cci:7://file:///C:/Users/RillG/IdeaProjects/TenderBotStoreIdentityService/README.md:0:0-0:0).
        - Нормализация ссылок в всех копируемых MD: автоматическая замена `](…) .md` → `](…)` для корректного рендера Wiki.
        - `_Sidebar.md` теперь тоже с “чистыми” ссылками.

    - Причина изменений:
        - B2-DC-3: сделать требования ролей и аутентификации явными в Swagger.
        - Исправить рендеринг Wiki: ранее переходы открывали сырые [.md](cci:7://file:///C:/Users/RillG/IdeaProjects/TenderBotStoreIdentityService/README.md:0:0-0:0).

    - Как проверить:
        - Запустить сервис; открыть Swagger UI: `http://localhost:8081/swagger-ui.html` (или `/swagger-ui`) и убедиться, что описания ролей/аутентификации присутствуют.
        - Сделать любой пуш, затрагивающий `docs/**` — проверить вкладку Wiki:
            - Home корректно отрендерен.
            - Переход по ссылкам внутри Wiki открывает форматированные страницы.

    - Backward compatibility:
        - Функциональность эндпоинтов не менялась, только документация/README/CI workflow.

# Статус изменений
- **[README.md]** — добавлен раздел “Онлайн Wiki”, добавлены инструкции по Swagger.
- **[.github/workflows/docs-wiki-pr.yml]** — генерация Home, нормализация ссылок, Sidebar без [.md](cci:7://file:///C:/Users/RillG/IdeaProjects/TenderBotStoreIdentityService/README.md:0:0-0:0).
- **[Контроллеры]** — аннотированы `@Operation` с пометками RBAC/auth.
